### PR TITLE
Initial creation of missing classes

### DIFF
--- a/Classes/Barbarian.md
+++ b/Classes/Barbarian.md
@@ -7,6 +7,7 @@ publish:
 tags: [13A/Characters/Classes/Barbarian]
 updated:: 2023-04-30
 ---
+
 # Barbarian
 
 ## Ability Scores

--- a/Classes/Bard.md
+++ b/Classes/Bard.md
@@ -395,15 +395,15 @@ __Hit:__ 1d4 + Charisma thunder damage.
 
 9th level spell: 10d4 damage.
 
-Adventurer Feat
+__Adventurer Feat__
 
 Your *battle chant* damage dice are now d6s instead of d4s.
 
-Champion Feat
+__Champion Feat__
 
 Once per day, you can expend one of your recoveries to reroll a *battle chant* attack roll.
 
-Epic Feat
+__Epic Feat__
 
 One battle per day, your *battle chant* damage dice become d10s.
 
@@ -429,15 +429,15 @@ __Natural Even Miss:__ The target is dazed until the end of your next turn.
 
 9th level spell: Target with 266 hp or fewer.
 
-Adventurer Feat
+__Adventurer Feat__
 
 Recharge check is now 6+.
 
-Champion Feat
+__Champion Feat__
 
 The target of the spell doesn’t have to be nearby, just in line of sight.
 
-Epic Feat
+__Epic Feat__
 
 On a hit, the confusion effect is now save ends.
 
@@ -487,15 +487,15 @@ __Miss:__ Half damage, and deal thunder damage equal to your level to each of yo
 
 9th level spell: 3d6 x 10 damage.
 
-Adventurer Feat
+__Adventurer Feat__
 
 On a natural even hit, the dazed effect is now save ends.
 
-Champion Feat
+__Champion Feat__
 
 The spell is now recharge 16+ after battle instead of daily.
 
-Epic Feat
+__Epic Feat__
 
 You can now target 1d4 + 1 enemies in a group with the spell.
 
@@ -509,15 +509,15 @@ __Triggering Roll:__ Natural odd roll
 
 __Effect:__ Give a nearby ally temporary hit points equal to your Charisma modifier.
 
-Adventurer Feat
+__Adventurer Feat__
 
 If the ally is staggered, double the temporary hit points.
 
-Champion Feat
+__Champion Feat__
 
 Add your level to the temporary hit points given (add before any doubling).
 
-Epic Feat
+__Epic Feat__
 
 You can choose yourself instead of an ally as the target of the battle cry.
 
@@ -529,15 +529,15 @@ __Triggering Roll:__ Natural even miss
 
 __Effect:__ This battle, your next ally to attack the target you missed gains a +2 attack bonus with that attack.
 
-Adventurer Feat
+__Adventurer Feat__
 
 That ally’s attack also deals +1d6 damage.
 
-Champion Feat
+__Champion Feat__
 
 The damage bonus increases to +3d6.
 
-Epic Feat
+__Epic Feat__
 
 The damage bonus increases to +3d12.
 
@@ -593,11 +593,11 @@ __Final Verse:__ Make the attack again, but this time it deals half damage on a 
 
 9th level song: 10d12 damage.
 
-Champion Feat
+__Champion Feat__
 
 The number of targets increases to 2d4.
 
-Epic Feat
+__Epic Feat__
 
 Two of the targets can now be far away instead of nearby.
 
@@ -623,15 +623,15 @@ __Miss:__ Damage equal to your level.
 
 9th level spell: 2d8 x 10 damage.
 
-Adventurer Feat
+__Adventurer Feat__
 
 On a hit, the effect that damages the target when it misses is now save ends.
 
-Champion Feat
+__Champion Feat__
 
 Recharge check is now 6+.
 
-Epic Feat
+__Epic Feat__
 
 A natural even miss does not expend the spell.
 
@@ -651,15 +651,15 @@ __Effect:__ Each target can heal using a recovery.
 
 9th level spell: Add +25 hp to the recovery.
 
-Adventurer Feat
+__Adventurer Feat__
 
 The spell is now recharge 16+ after battle instead of daily.
 
-Champion Feat
+__Champion Feat__
 
 Add a third random target.
 
-Epic Feat
+__Epic Feat__
 
 The recoveries the targets use are now free.
 
@@ -681,11 +681,11 @@ __Triggering Roll:__ Natural 16+ if the escalation die is 5+; otherwise natural 
 
 __Effect:__ A nearby ally can heal using a recovery, and three nearby allies gain a +3d6 damage bonus to their next damage roll this battle.
 
-Champion Feat
+__Champion Feat__
 
 The battle cry can now trigger when the escalation die is 3+ instead of 5+.
 
-Epic Feat
+__Epic Feat__
 
 The damage bonus is now +3d12.
 

--- a/Classes/Chaos Mage.md
+++ b/Classes/Chaos Mage.md
@@ -1,0 +1,1143 @@
+---
+aliases: [Chaos Mage]
+created: 2023-05-03
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Chaos Mage]
+updated:: 2023-05-03
+---
+
+# Chaos Mage
+
+### Ability Scores
+
+Chaos Mages gain a +2 class bonus to Intelligence or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+### Backgrounds
+
+Possible backgrounds include: 
+- Blossoming witch
+- Jester
+- Fireworks exhibitionist
+- No-longer-frustrated librarian
+- Stirge wrangler
+- Living spell
+- Living dungeon denizen
+- Wandering musician
+- Hero from another world
+
+### Gear
+
+At 1st level, chaos mages start with adventuring clothes, a simple dagger (or a uniquely weird but similarly powerful weapon befitting to their background), and any other minor (and unusual) elements of gear their backgrounds suggest.
+
+#### Gold Pieces
+
+Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| __Armor Type__ | __Base AC__ | __Atk Penalty__ |
+| ---------- | ------- | ----------- |
+| None       | 10      | -           |
+| Light      | 10      | -           |
+| Heavy      | 11      | -2          |
+| Shield     | +1      | -2          |
+
+### Melee Weapons
+
+|                  | __One-Handed__                   | __Two-Handed__            |
+| ---------------- | -------------------------------- | ------------------------- |
+| Small            | 1d4 dagger, pronged fork         | 1d6 club, staff           |
+| Light or Simple  | 1d6 (-2 atk) axe, shortsword     | 1d8 (-4 atk) spear        |
+| Heavy or Martial | 1d8 (-5 atk) scimitar, warhammer | 1d10 (-6 atk) greatsword |
+
+### Ranged Weapons
+
+|                  | __Thrown__           | __Crossbow__                | __Bow__               |
+| ---------------- | -------------------- | --------------------------- | --------------------- |
+| Small            | 1d4 dagger, star     | 1d4 hand crossbow           | -                     |
+| Light or Simple  | 1d6 (-2 atk) javelin | 1d6 (-1 atk) light crossbow | 1d6 (-2 atk) shortbow |
+| Heavy or Martial | -                    | 1d8 (-4 atk) heavy crossbow | 1d8 (-5 atk) longbow           |
+
+## Level Progression
+
+| Chaos Mage Level   | Total Hit Points           | Total Feats                    | Daily Spells (M) | Once-per-Battle Spells (M) | Spell Level (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|------------------|----------------------------|-----------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | 1                | 1                          | 1st level       | Not affected             | ability modifier                |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   | 2                | 1                          | 1st level       | —                        | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 3                | 1                          | 1st level       | —                        | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 3                | 1                          | 3rd level       | —                        | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | 4                | 1                          | 3rd level       | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        | 4                | 1                          | 5th level       | —                        | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | 4                | 2                          | 5th level       | —                        | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | 4                | 2                          | 7th level       | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 5                | 2                          | 7th level       | —                        | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 5                | 2                          | 9th level       | —                        | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 6                | 2                          | 9th level       | +1 to 3 abilities        | 3 x ability modifier            |
+
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+Note: Although not listed on the table, this class gets three talents. It does not get more at higher levels.
+
+## Stats
+
+| Ability Bonus                        | +2 Intelligence or Charisma (different from racial bonus)    |
+|--------------------------------------|--------------------------------------------------------------|
+| Initiative                           | Dex mod + Level                                              |
+| Armor Class (heavy armor)            | 10 + middle mod of Con/Dex/Wis + Level                       |
+| Armor Class (shield and heavy armor) | 10 + middle mod of Str/Con/Dex + Level                       |
+| Physical Defense                     | 11 + middle mod of Int/Wis/Cha + Level                       |
+| Mental Defense                       | (6 + Con mod) x Level modifier (see level progression chart) |
+| Hit Points                           | 8                                                            |
+| Recoveries                           | (1d6 x Level) + Con mod                                      |
+| Recovery Dice                        | 8 points, max 5 in any one background                        |
+| Backgrounds                          | 3 points (4 at 5th level; 5 at 8th level)                    |
+| Icon Relationships                   | 3                                                            |
+| Talents                              | 1 per Level                                                  |
+
+## Basic Attacks
+
+### Melee Attack
+
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** —
+
+### Ranged Attack
+
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+Chaos mages use arcane implements, such as wands and staffs, to improve their attacks. Unlike wizards and clerics, chaos mages don’t choose the spells they know. Instead, a chaos mage of a given level can access all the spells in a category that are their level or lower.
+
+The category of spell you’ll cast on your turn is randomly decided, but you get to decide how many of your resources you’ll use. You have a limited number of daily and once-per-battle spells, so each turn you must decide whether to use one of the powerful spells in the category you’re casting from or whether you’ll stick with an at-will spell.
+
+Chaos mages are not allowed to cast rituals.
+
+### Chaos Magic
+Chaos magic has three main categories of spells: attack, defense, and iconic.
+
+Since the category of magic spells you’ll cast is randomly chosen, you’ll need 6 “stones” (gems, beads, poker chips, or whatever you like) of three different colors—two stones for each color. You’ll also need a bag (or cup) to put them in and draw them from. Put two of each color into the bag, then assign one color to attack, one color to defense, and the last color to iconic.
+
+If you’d rather use dice instead of stones in a bag, use a d6; 1-2 is attack, 3-4 is defense, 5-6 is iconic.
+
+You draw a stone from the bag to determine the next type of spell you’ll be able to cast. You usually do this when you roll initiative at the start of a battle, at the end of your turn (to set up the spell you can cast during your next turn), or as required during your turn if you somehow get an extra standard action.
+
+Each stone you draw should be set aside so that each turn you draw from a smaller pool of stones. When there is one stone left in the bag, don’t draw it. Instead, refill the bag with the other six stones and draw. At the end of the battle, refill the bag.
+
+If you draw…
+-   Attack: The next chaos mage spell you cast during the battle must be an attack spell, but you won’t have to choose the spell until your turn.
+-   Defense: The next chaos mage spell you cast during the battle must be a defense spell, but you won’t have to choose the spell until your turn.
+-   Iconic: The next chaos mage spell you cast during the battle must be an iconic spell. Immediately roll a die to determine which icon’s spells you’ll have to choose from. For example, if there are 12 icons in your game, assign a number to each icon and roll a d12. You don’t have to choose the specific spell until your turn.
+
+Whether you cast an at-will, per-battle, or daily spell, you cast it at the spell level shown on the spell progression table.
+
+__Adventurer Feat__
+Once per day when you cast an iconic daily or once-per-battle spell from an icon you have at least a one-point relationship with, roll a normal save. If you succeed, you don’t expend that spell, allowing you to cast it again, or another daily/once-per-battle spell.
+
+__Champion Feat__
+Once per day when you draw an iconic spell, before rolling, choose an icon you have at least a one-point relationship with. The spell you cast next will be from that icon.
+
+__Epic Feat__
+You can use the champion feat power a second time, but only if you choose an icon that you have at least a two-point relationship with.
+
+__High Weirdness__
+Chaos mages usually display an uncanny weirdness that presents itself through their spellcasting, and sometimes even bleeds through to their general demeanor. This weirdness is represented in game mechanics through the High Weirdness table below.
+
+When an enemy scores a critical hit against you, roll high weirdness and consult the table to see what effect applies. If you hate the effect you’re experiencing, you can use a standard action to change it. Unless otherwise specified, the high weirdness effects last until the end of the battle.
+
+Unless otherwise specified, the high weirdness effects last until the end of the battle.
+
+__Adventurer Feat__
+If you have one or more Warp talents, whenever you make a d6 roll for one, also roll for a new high weirdness effect. The new effect replaces the weirdness effect currently active, if any.
+
+If you have no Warp talents, roll for a new high weirdness effect whenever you draw an iconic spell.
+
+__Champion Feat__
+Once per battle when you roll for a high weirdness effect, roll twice and use both results. Reroll duplicate results.
+
+__Epic Feat__
+One battle per day, each time you roll for a high weirdness effect, roll twice and use both results. Reroll duplicate results.
+
+__High Weirdness Table__
+| d100  | High Weirdness Effect                                                                                                                                                                                                                                                                                                                                                                                                           |
+|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1–2   | You accidentally summon 1d3 wibbles that either attack you or drift off to wreak a small amount of havoc elsewhere in the battle.                                                                                                                                                                                                                                                                                               |
+| 3–4   | You’re hit by a pulsing wrinkle in time. You move and speak ever–so–slightly slower than you should until you catch up. There’s no effect this turn, but at the end of your turn, decrease your initiative 2d6 points, to a minimum of 1.                                                                                                                                                                                       |
+| 5–6   | Each creature in the battle with temporary hit points loses half of them.                                                                                                                                                                                                                                                                                                                                                       |
+| 7–8   | You can only speak by asking questions. If you or your character violates this requirement, your character takes 1 damage the first time, 2 damage the second time, and so on. (Have another player keep track.)                                                                                                                                                                                                                |
+| 9–10  | Your magic items’ quirks take over. If you aren’t doing a good enough job of roleplaying this personality fiasco, the GM and the rest of the players are authorized to suggest (in)appropriate behavior.                                                                                                                                                                                                                        |
+| 11    | You leech personality traits from surrounding spirits, whatever those happen to be. These are only traits, not personality overrides.                                                                                                                                                                                                                                                                                           |
+| 12    | You must speak in what you think could be the voice of the last creature your chaos mage attacked. If it doesn’t seem to have a voice, invent one.                                                                                                                                                                                                                                                                              |
+| 13    | Small squeaking rodents erupt from any plausible cover that you go near. There’s no real effect except they’re somewhat noisy and rodents suddenly pop up in unexpected places.                                                                                                                                                                                                                                                 |
+| 14    | Your (the PC) favorite song begins playing around you magically, getting louder and louder (tell the table what type of song it is, or maybe hum it). It might or might not interfere with bardic songs or monsters that need to be heard properly to get their dirty work done.                                                                                                                                                |
+| 15    | A disembodied voice begins narrating the events of the battle to all participants. The voice isn't necessarily on your side, pick a random icon it seems to be associated with.                                                                                                                                                                                                                                                 |
+| 16    | You grow horns or other spikes all over. If you already have horns, then you lose them. Some of the horns, or lack thereof, persist after the weirdness ends.                                                                                                                                                                                                                                                                   |
+| 17    | One of your arms becomes a functional tentacle. It has no mechanical effects, but unless you’re special or lucky it’s probably not a very pretty tentacle. Your option on whether or not it remains after the weirdness ends.                                                                                                                                                                                                   |
+| 18    | A great gust of wind circles around the battlefield. It probably has no serious effect unless there’s something happening that a great gust of wind could seriously affect.                                                                                                                                                                                                                                                     |
+| 19    | All creatures leave colored trails behind them as they move, turning the battle scene into a strange glowing artwork. Images fade every ten seconds or so.                                                                                                                                                                                                                                                                      |
+| 20    | Some minor detail of your appearance changes hair color, gaps between teeth, handedness, and so on. The change is permanent–ish.                                                                                                                                                                                                                                                                                                |
+| 21–22 | Grit, explosive dust, or other debris explodes into the air around you, dealing 1d4 damage per tier to each nearby creature.                                                                                                                                                                                                                                                                                                    |
+| 23–24 | There’s tension in the air, or the rumble of distant thunder, or a sense of impending disaster, and the next creature that misses with an attack this battle takes damage equal your Charisma modifier (double your Charisma modifier at 5th level; triple it at 8th level).                                                                                                                                                    |
+| 25–26 | Quickly passing auras blur and shake across the battlefield, or cold winds whip through and grow warmer as they pass, or the lights flicker . . . and the creature that has taken the most damage in the battle gains temporary hit points equal to 10% of its maximum hit points.                                                                                                                                              |
+| 27–28 | One random creature in the battle other than you teleports next to and is engaged by one of its random enemies other than you.                                                                                                                                                                                                                                                                                                  |
+| 29–30 | (Global effect) Space seriously twists, affecting the spells and ranged attacks of each creature in the battle creatures that are nearby count as if they were faraway, and creatures that are faraway count as if they are nearby.                                                                                                                                                                                             |
+| 31–32 | The first spell you cast this battle has effects (not damage) like a spell two levels higher than it, if possible.                                                                                                                                                                                                                                                                                                              |
+| 33–34 | (Global effect) All normal saves made by creatures in the battle are actually easy saves (6+).                                                                                                                                                                                                                                                                                                                                  |
+| 35–36 | (Global effect) There’s a blurring at the edge of all things. No creature can intercept another. Disengage attempts automatically succeed.                                                                                                                                                                                                                                                                                      |
+| 37–38 | (Global effect) The champions shall inherit the dirt! Until the end of your next turn, saves that fail count as if they succeed, and saves that succeed count as if they fail!                                                                                                                                                                                                                                                  |
+| 39–40 | Roll the escalation die and use the new result.                                                                                                                                                                                                                                                                                                                                                                                 |
+| 41–42 | (Global effect) Each creature in the battle taking ongoing damage immediately takes that damage. Then all ongoing damage effects end.                                                                                                                                                                                                                                                                                           |
+| 41–42 | (Global effect) Each creature in the battle taking ongoing damage immediately takes that damage. Then all ongoing damage effects end.                                                                                                                                                                                                                                                                                           |
+| 43–44 | (Global effect) Each creature that makes an attack targeting PD targets MD instead. Attacks against MD target PD instead.                                                                                                                                                                                                                                                                                                       |
+| 45–46 | Your shadow detaches and flits around you. Until the weirdness ends, you gain a +2 attack bonus but take a –2 penalty to saves. Your personality may or may not be affected. It’s up to you.                                                                                                                                                                                                                                    |
+| 47–48 | Choose yourself or one ally with temporary hit points and double those temporary hit points.                                                                                                                                                                                                                                                                                                                                    |
+| 49–50 | There’s a large magical special effect of your choice (non-mechanical), and each creature in the battle ignores all resistances.                                                                                                                                                                                                                                                                                                |
+| 51–55 | You gain an additional quick action during each of your turns while this weirdness is in effect.                                                                                                                                                                                                                                                                                                                                |
+| 56–60 | When one of your allies casts an arcane spell this battle, the spell gains a small bonus effect chosen by the GM (something that suits the spell and the story).                                                                                                                                                                                                                                                                |
+| 61–65 | You and your allies gain small halos, or celestial light pours in, or a subtle glow illuminates each countenance. When one of your allies casts a divine spell this battle, it gains a small bonus effect chosen by the GM, something that suits the spell and the story.                                                                                                                                                       |
+| 66–70 | Your features shift and settle into a temporary new pattern. You gain a random racial ability until the end of your next turn. Ignore results that duplicate a racial ability you already have. Roll a d8. 1: dwarf’s that’s your best shot; 2: dark elf’s cruel; 3: high elf’s highblood teleport; 4: gnome’s confounding; 5: half–elf’s surprising; 6: halfling’s evasive; 7: holy one’s halo; 8: tieflings’s curse of chaos. |
+| 71–75 | If one of your allies is at 0 hit points or below, that ally can roll a free death save that won’t count against their missed death save total.                                                                                                                                                                                                                                                                                 |
+| 76–80 | Choose one creature (including you) that has already rallied this battle. It can rally again this battle (using the same action it normally would) as if it hadn’t already rallied (no roll if the first use).                                                                                                                                                                                                                  |
+| 81–85 | Your presence blurs through space, spirit, and time, and you can fight in spirit on your turn (see Combat Rules, Special Action) in addition to taking your normal turn.                                                                                                                                                                                                                                                        |
+| 86–90 | You shift, you waver, or you go transparent. You don’t take any miss damage while this weirdness is affecting you.                                                                                                                                                                                                                                                                                                              |
+| 91–95 | The magic items in the area all start talking at once. You or one ally of your choice can roll to recharge one magic item (affected creature’s choice).                                                                                                                                                                                                                                                                         |
+| 96–97 | Something related to your one unique thing goes very right for you. This is on you and the GM to work out together. The GM has the final say, though.                                                                                                                                                                                                                                                                           |
+| 98    | If you and your allies flee RIGHT NOW, you don’t take a campaign loss for your discretion. This may take some explaining. It’s all about the chaos magic.                                                                                                                                                                                                                                                                       |
+| 99    | Roll twice more on this table. If you wish you can ignore one of the rolled results but must stick with the other. If you roll the same result twice, you get that weirdness just once.                                                                                                                                                                                                                                         |
+| 100   | You gain an extra standard action during the next turn after this weirdness goes into effect.                                                                                                                                                                                                                                                                                                                                   |
+
+## Class Talents
+
+Choose three of the following class talents.
+
+### Warp Talents
+
+There are three separate Warp talents that you may choose from. They provide random powers or features that surface unpredictably during battles (and perhaps during non-combat moments of high tension).
+
+If a warp talent gives you access to a spell from another class, associate it with chaos magic’s attack category or defense category. You can then cast it if that spell type comes up for you.
+
+#### Attacking Warp
+
+Your magic provides you with a random warp effect when the next spell you cast will be an attack spell. This talent works best for chaos mages with a high Dexterity.
+
+When your random spell choice indicates an attack spell, roll a d6 to determine the effect you’ll gain from the elemental warp. Even though you can’t cast the spell until your next turn, the warp effect applies now.
+
+| d6 | Effect                                                                                                                                                                                             |
+|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1  | Air: You gain flight until the end of your next turn.                                                                                                                                              |
+| 2  | Earth: Until the end of your next turn, each enemy that misses you with a melee attack is stuck until the end of its next turn.                                                                    |
+| 3  | Fire: Until the end of your next turn, you can pop free from staggered enemies as a quick action.                                                                                                  |
+| 4  | Water: You gain a bonus to disengage checks until the end of your next turn equal to your Dexterity modifier                                                                                       |
+| 5  | Metal: Until the end of your next turn, when an enemy disengages from you, it takes damage equal to your Dexterity modifier (double your Dexterity modifier at 5th level; triple it at 8th level). |
+| 6  | Void: During your next turn, you can use a move action to teleport to a nearby location you can see.                                                                                               |
+
+__Adventurer Feat__
+When you roll a successful disengage check, you gain temporary hit points equal to your Dexterity modifier (double your Dexterity modifier at 5th level; triple it at 8th level).
+
+__Champion Feat__
+While you are flying due to any effect, you gain a bonus to disengage checks equal to your Dexterity modifier.
+
+__Epic Feat__
+When one of your spells or powers lets you teleport to a nearby location, you can instead teleport to a faraway location you can see.
+
+#### Defensive Warp
+
+Your magic provides you with a random warp effect when the next spell you cast will be a defense spell. This talent works best for chaos mages with a high Wisdom.
+
+When your random spell choice indicates a defense spell, roll a d6 to determine the effect you’ll gain from the elemental warp. Even though you can’t cast the spell until your next turn, the warp effect applies now.
+
+| d6 | Effect                                                                                                                                                                                                   |
+|----|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1  | Air: Once before the end of your next turn, you can heal using a recovery as a quick action.                                                                                                             |
+| 2  | Earth: You gain temporary hit points equal to your Wisdom modifier (double your Wisdom modifier at 5th level; triple it at 8th level).                                                                   |
+| 3  | Fire: Until the end of your next turn, when an enemy moves to engage you, it takes fire damage equal to your Wisdom modifier (double your Wisdom modifier at 5th level; triple it at 8th level).         |
+| 4  | Water: Until the end of your next turn, when you heal using a recovery, add hit points equal to your Wisdom modifier to that healing (double your Wisdom modifier at 5th level; triple it at 8th level). |
+| 5  | Metal: Until the end of your next turn, you gain a +2 bonus to AC.                                                                                                                                       |
+| 6  | Void: Until the end of your next turn, the first time an attack hits you, as a free action you can choose to lose hit points equal to your level to force the attacker to reroll the attack.             |
+
+__Adventurer Feat__
+When you heal using a recovery, add hit points equal to the escalation die to that healing.
+
+__Champion Feat__
+While you are at maximum hit points, you gain a +1 bonus to all defenses.
+
+__Epic Feat__
+When an attacker rerolls an attack against you, it takes an attack penalty equal to your Wisdom modifier.
+
+#### Iconic Warp
+
+Your magic provides you with a random warp effect when the next spell you cast will be an iconic spell. This talent works best for chaos mages with a high Intelligence.
+
+When your random spell choice indicates an iconic spell, roll a d6 to determine the effect you’ll gain from the elemental warp. Even though you can’t cast the spell until your next turn, the warp effect applies now.
+
+| d6 | Effect                                                                                                                                                                                                                                   |
+|----|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1  | Air: Randomly determine two icon associations for the spell you’ll cast instead of one. Choose one of those associations to use for that spell.                                                                                          |
+| 2  | Earth: Until the end of your next turn, you gain a bonus to PD and MD equal to your Intelligence modifier.                                                                                                                               |
+| 3  | Fire: Until the end of your next turn, you gain the once-per-battle racial power of a random nearby ally; ignore this benefit if it duplicates your own racial power or if it doesn’t make sense during the battle (human, for example). |
+| 4  | Water: Until the end of your next turn, you gain a bonus to saves equal to your Intelligence modifier.                                                                                                                                   |
+| 5  | Metal: Until the end of your next turn, critical hits scored against you only count as normal hits.                                                                                                                                      |
+| 6  | Void: When you roll a natural 20 with an attack, the critical hit range of your attacks expands by 2 until the end of the battle (cumulative).                                                                                           |
+
+__Adventurer Feat__
+Once per battle when you roll for an iconic warp effect, roll the d6 twice and choose the result you want.
+
+__Champion Feat__
+When you roll a natural 18–20 on a save, a nearby ally of your choice can roll a save against a save ends effect.
+
+__Epic Feat__
+When you roll a natural 20 with an attack, the critical hit range of your attacks expands by 2 until the end of the battle (cumulative).
+
+### Separate Existence
+
+You are ever-so-slightly detached from normal physical reality. Play the story side of that as you like; the game mechanics side is that you can cast ranged spells while engaged with enemies without taking opportunity attacks.
+
+__Adventurer Feat__
+While you have an _air_ or _void_ warp effect active, you take no damage from missed attacks.
+
+__Champion Feat__
+When you teleport, you can heal using a recovery.
+
+### Stench of Necromancy
+
+You gain a random spell from the necromancer class. Whenever you take a full heal-up, randomly choose a necromancer spell of the highest level you can cast. For the rest of the day, you know this necromancer spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
+
+If the necromancer spell refers to Intelligence, you can replace that ability score with references to Charisma.
+
+__Adventurer Feat__
+One battle per day, you can gain the Cackling Soliloquist talent from the necromancer class.
+
+__Champion Feat__
+While you have an _earth_ or _metal_ warp effect active, when an enemy in the battle drops to 0 hp, you gain temporary hit points equal to your Charisma modifier (double your Charisma modifier at 5th level; triple it at 8th level).
+
+__Epic Feat__
+If you don’t like the first random necromancer spell you select for the day, you can determine another random necromancer spell. You’re stuck with the second one.
+
+### Touch of Wizardry
+
+You gain a random spell from the wizard class. Whenever you take a full heal-up, randomly choose a wizard spell of the highest level you can cast. For the rest of the day, you know this wizard spell and can cast it according to its normal usage pattern—at-will, cyclic, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
+
+If the wizard spell refers to Intelligence, you can replace that ability score with references to Charisma.
+
+__Adventurer Feat__
+You gain a random wizard talent at the start of each day. Roll a d3. 1: Abjuration; 2: Evocation; 3: High Arcana (_counter magic_). Replace references to “wizard” in these talents with “chaos mage” and Intelligence with Charisma.
+
+__Champion Feat__
+You gain a single daily use of the wizard’s _utility spell_, cast at your level or lower.
+
+__Epic Feat__
+If you don’t like the first random wizard spell you select for the day, you can determine another random wizard spell. You’re stuck with the second one.
+
+### Trace of the Divine
+
+You gain a random spell from the cleric class. Whenever you take a full heal-up, randomly choose a cleric spell of the highest level you can cast. For the rest of the day, you know this cleric spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
+
+If the cleric spell refers to Wisdom, you can replace that ability score with references to Charisma.
+
+__Adventurer Feat__
+At the start of the day, choose a random cleric invocation, excepting those from the healing domain. You can use that invocation as if you were a cleric once this day as a quick action.
+
+__Champion Feat__
+While you have an _air_ or _water_ warp effect active, when you heal using a recovery or cast a spell that lets an ally heal using a recovery, add an extra recovery die to the healing.
+
+__Epic Feat__
+In addition to the random invocation you gain at the start of the day, you also get the talent/domain powers that go with it.
+
+### Whiff of Sorcery
+
+You gain a random spell from the sorcerer class. Whenever you take a full heal-up, randomly choose a sorcerer spell of the highest level you can cast. For the rest of the day, you know this sorcerer spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
+
+__Adventurer Feat__
+Twice per day, you can gather power as if you were a sorcerer in order to deal double damage with either a sorcerer spell or a chaos mage spell the next time you cast a spell. You also gain the chaotic benefit for gathering power. (Note that you should have already determined the type of spell you will be casting, since you select a spell type when you roll initiative and at the end of each turn, so you’re generally better off waiting to gather power when you know you have an attack or iconic spell coming.)
+
+__Champion Feat__
+While you have an _air_ or _fire_ warp effect active, add fire damage equal to your Charisma modifier to your miss damage (double your Charisma modifier at 5th level; triple it at 8th level).
+
+__Epic Feat__
+If you don’t like the first random sorcerer spell you select for the day, you can determine another random sorcerer spell. You’re stuck with the second one.
+
+## Attack Spells (1st Level+)
+
+#### Force Tentacle
+
+Ranged spell
+
+At-Will
+
+**Target:** One random nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d10 + Charisma force damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d10 damage.
+
+5th level spell: 5d10 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 9d10 damage.
+
+__Adventurer Feat__
+
+You can now also target faraway enemies.
+
+__Champion Feat__
+
+This spell’s damage dice increase by one size to d12s.
+
+__Epic Feat__
+
+One battle per day, you can deal half damage on a natural even miss with this spell.
+
+#### Chaos Ray
+
+Ranged spell
+
+Once per battle
+
+**Target:** One nearby or faraway enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d8 + Charisma damage.
+
+**Natural Even Hit:** As a hit, plus another nearby enemy takes half damage.
+
+**Miss:** 1d6 damage to a different nearby enemy.
+
+3rd level spell 4d6 damage: 1d10 damage on a miss.
+
+5th level spell 6d6 damage: 2d12 damage on a miss.
+
+7th level spell 6d10 damage: 3d12 damage on a miss.
+
+9th level spell 8d10 damage: 5d12 damage on a miss.
+
+#### Blarrrrgh!
+
+Ranged spell
+
+Daily
+
+**Targets:** 1d6 nearby enemies
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 3d6 + Charisma damage, and roll a d4 for the effect (same damage for all targets but a separate effect for each one).
+
+| d4 | Effect                                                  |
+|----|---------------------------------------------------------|
+| 1  | The target is dazed (save ends).                        |
+| 2  | The target is weakened (save ends).                     |
+| 3  | The target is hampered until the end of your next turn. |
+| 4  | The target is confused until the end of your next turn. |
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 6d6 damage.
+
+5th level spell: 6d10 damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+### Defense Spells (1st Level+)
+
+#### Chaos Blessing
+
+Close-quarters spell
+
+At-Will
+
+**Effect:** Roll a d20 to determine which effect the blessing grants. Higher-level versions of the spell improve the first three blessings, but you still get only the blessing you roll.
+
+| d20   | Effect                                                                                                                                                                           |
+|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1–4   | Gift—You or one of your nearby allies gains 7 temporary hit points.                                                                                                              |
+| 5–8   | Resilience—You gain 7 temporary hit points.                                                                                                                                      |
+| 9–12  | Aura/tentacles—The next enemy that moves to engage you this battle takes 2d6 damage.                                                                                             |
+| 13–16 | Defense bonus—You gain a +2 bonus to the defense of your choice (AC, PD, or MD) until an attack against that defense misses you or until the end of the battle.                  |
+| 17–20 | Healing—You or your nearby ally with the fewest hit points can heal using a recovery. (If you’re the one with the fewest hit points among you and your nearby allies, it’s you.) |
+
+3rd level spell: _gift_ and _resilience_ now grant 12 temporary hit points; _aura/tentacles_ damage is 2d10.
+
+5th level spell: _gift_ and _resilience_ now grant 20 temporary hit points; _aura/tentacles_ damage is 4d10.
+
+7th level spell: _gift_ and _resilience_ now grant 35 temporary hit points; _aura/tentacles_ damage is 6d8.
+
+9th level spell: _gift_ and _resilience_ now grant 60 temporary hit points; _aura/tentacles_ damage is 10d8.
+
+__Adventurer Feat__
+
+The _defense bonus_ effect now applies to all the target’s defenses (and therefore ends as soon as the target is missed by an attack).
+
+__Champion Feat__
+
+A number of times per day equal to your highest non-Charisma modifier, you can roll twice when you cast _chaos blessing_ and gain both effects (reroll a duplicate result).
+
+__Epic Feat__
+
+The damage dice for the _aura/tentacles_ effect increase by one size (for example, d8s to d10s).
+
+#### Warped Healing
+
+Close-quarters spell
+
+Once per battle
+
+**Targets:** Two nearby allies, or you and one nearby ally
+
+**Effect:** Randomly choose one of the targets. That target can heal using a recovery. The other target gains 10 temporary hit points and grows a strange eye, limb, or other physical feature that lasts as long as the temporary hit points do.
+
+3rd level spell: 20 temporary hit points.
+
+5th level spell: 30 temporary hit points.
+
+7th level spell: 45 temporary hit points.
+
+9th level spell: 70 temporary hit points.
+
+### Iconic Spells & Feats
+
+In setting up your game universe, you should have a set of icons. Distribute them more or less evenly into the spell groups below according to the theme that matches best (Blood of Warriors, Light of the High Ones, Twisted Path). When the chaos mage rolls a particular icon, they can choose any spell associate that that icon’s group of spells.
+
+Multiple icons should belong to each group. Each group should have at-will spells and at least one per-battle and daily spell.
+
+#### Blood of Warriors
+
+##### Castigation (1st level+)
+
+Close-quarters spell
+
+At-Will
+
+**Target:** One enemy you are engaged with if possible; if not, then one nearby enemy
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** 1d8 + Charisma psychic damage
+
+**Hit vs. a Staggered Target:** As a hit, except there is no damage roll; the target takes maximum damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d6 damage.
+
+5th level spell: 5d6 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 6d10 damage.
+
+__Adventurer Feat__
+
+When you hit a demon with this spell, it’s also hampered (save ends).
+
+__Champion Feat__
+
+The damage dice for the spell increase by one size (for example, d6s to d8s).
+
+__Epic Feat__
+
+The spell now deals half damage on a miss.
+
+##### Terribly Spiky Armor (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** Until the end of the battle, you gain a +3 bonus to AC and when an enemy engaged with you misses you with an attack, it takes 3d6 + Charisma damage.
+
+5th level spell: 5d6 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d10 damage.
+
+##### Yours! (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** You or one ally in the battle, chosen randomly
+
+**Effect:** Roll a d20.
+
+_1–10:_ The target can heal using a recovery.
+
+_11–20:_ The target can make a basic attack as a free action.
+
+__Adventurer Feat__
+
+When this spell allows a target to attack, the attack deals half damage on a miss instead of normal miss damage.
+
+__Champion Feat__
+
+The target can move as a free action before using a recovery or attacking.
+
+__Epic Feat__
+
+When the target heals using a recovery, it adds hit points equal to 1d10 x the escalation die to that healing.
+
+##### Ours! (1st level+)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby ally
+
+**Effect:** The target can heal using a free recovery, adding hit points equal to 1d6 x the escalation die to that healing. Unless you or the target is a dwarf, randomly choose one of the target’s true magic items. You actively gain that item’s quirk until the end of the day.
+
+##### Fiery Claw (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Special:** This spell attack ignores all the target’s resistances.
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d8 + Charisma fire damage, and the target loses its _resist damage_ abilities, if any (hard save ends, 16+).
+
+**Miss:** Damage equal to your level.
+
+3rd level spell 3d8 damage.
+
+5th level spell 5d8 damage.
+
+7th level spell 7d8 damage.
+
+9th level spell 9d8 damage.
+
+__Adventurer Feat__
+
+This spell can now deal holy damage instead of fire damage.
+
+__Champion Feat__
+
+The damage dice for this spell increase from d8s to d10s.
+
+__Epic Feat__
+
+This spell now deals half damage on a miss.
+
+##### Final Wrath (5th level+)
+
+Ranged spell
+
+Daily
+
+**Targets:** 1d4 nearby enemies in a group
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 7d6 + Charisma fire damage.
+
+**Natural Even Hit:** As a hit, plus if the target is staggered after the attack, it’s also stunned until the end of its next turn.
+
+**Miss:** Damage equal to your level.
+
+7th level spell: 9d10 damage.
+
+9th level spell: 2d6 x 10 damage.
+
+__Champion Feat__
+
+This spell now deals half damage on a miss.
+
+__Epic Feat__
+
+This spell now targets 2d3 enemies in a group.
+
+##### War Drums (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Effect:** The next natural odd attack roll you or one of your allies makes this battle that hits an enemy deals 13 extra damage.
+
+3rd level spell: 23 extra damage.
+
+5th level spell: 33 extra damage.
+
+7th level spell: 53 extra damage.
+
+9th level spell: 83 extra damage.
+
+__Adventurer Feat__
+
+Add your Charisma modifier to the extra damage (double your Charisma modifier at 5th level; triple it at 8th level).
+
+__Champion Feat__
+
+When you cast this spell, each nearby enemy that’s staggered also takes 2d6 thunder damage (4d6 thunder damage at 8th level).
+
+__Epic Feat__
+
+When this spell’s effect deals the extra damage, you can roll a hard save (16+). If you succeed, the _war drums_ keep beating and the effect extends to the next natural odd hit this battle! (And so on if you keep succeeding.)
+
+##### Savage Endings (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Targets:** Each nearby creature that’s staggered (yes, including allies, even those who are dying)
+
+**Effect:** Each target takes 5d6 + Charisma damage.
+
+5th level spell: 5d8 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 10d10 damage.
+
+__Adventurer Feat__
+
+The spell no longer targets your allies.
+
+__Champion Feat__
+
+The spell’s damage dice increase by one size (for example, d10s to d12s).
+
+__Epic Feat__
+
+When you drop one or more non-mook creatures to 0 hp with this spell, you can heal using a free recovery.
+
+#### Light of the High Ones
+
+##### Silver Arrows (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Targets:** 1d3 nearby enemies
+
+**Effect:** The target takes 4 force damage.
+
+3rd level spell: 7 damage.
+
+5th level spell: 10 damage.
+
+7th level spell: 14 damage.
+
+9th level spell: 27 damage.
+
+__Adventurer Feat__
+
+This spell now targets 1d4 nearby or faraway enemies.
+
+__Champion Feat__
+
+This spell now targets 1d6 nearby or faraway enemies.
+
+__Epic Feat__
+
+This spell now targets a number of nearby or faraway enemies equal to the escalation die.
+
+##### Cascading Power (5th level+)
+
+Ranged spell
+
+Daily
+
+**Targets:** A number of random nearby creatures equal to the escalation die
+
+**Effect:** The targets are embroiled in silver fire! Each targeted ally can roll an immediate easy save (6+); if that ally succeeds, they regain one daily or recharge power of their choice. Then each targeted enemy takes damage equal to 1d10 x the escalation die.
+
+After the damage, roll the escalation die and use the new result.
+
+7th level spell: Damage equal to 2d6 x the escalation die.
+
+9th level spell: Damage equal to 2d12 x the escalation die.
+
+##### Shards of Magic (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby or faraway enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Natural Even Hit:** 1d6 + Charisma force damage, and you can roll a hard save (16+). If you succeed, you get an extra standard action this turn.
+
+**Natural Odd Hit:** 7 ongoing damage.
+
+**Natural Even Miss:** You can teleport to a nearby location you can see as a free action.
+
+3rd level spell: Even hit: 3d6 damage; Odd hit: 10 ongoing damage.
+
+5th level spell: Even hit: 5d6 damage; Odd hit: 18 ongoing damage.
+
+7th level spell: Even hit: 5d8 damage; Odd hit: 28 ongoing damage.
+
+9th level spell: Even hit: 7d10 damage; Odd hit: 40 ongoing damage.
+
+__Adventurer Feat__
+
+A natural odd miss now deals damage equal to your level.
+
+__Champion Feat__
+
+A natural odd miss now deals half the force damage an even hit would have dealt.
+
+__Epic Feat__
+
+A natural even miss now allows you to teleport to a faraway location you can see as a free action.
+
+##### Coronation (3rd level+)
+
+Close-quarters spell
+
+Daily
+
+**Effect:** Until the end of the battle, when a staggered enemy hits you with an attack, you can make the following attack against that enemy as a free action after the attack.
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** The target is confused until the end of its next turn.
+
+__Champion Feat__
+
+Once per battle when a staggered enemy misses you with an attack while this spell’s effect is active, you can make the attack against that enemy.
+
+__Epic Feat__
+
+When you make a natural even roll with a _coronation_ attack, you can have the target become confused (save ends) instead of taking damage.
+
+##### Bolt and Thunder (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d4 + Charisma lightning damage, and a different random nearby enemy takes the same amount of thunder damage.
+
+3rd level spell: 2d6 damage.
+
+5th level spell: 3d6 damage.
+
+7th level spell: 5d6 damage.
+
+9th level spell: 5d8 damage.
+
+__Adventurer Feat__
+
+This spell now deals damage equal to your level on a miss.
+
+__Champion Feat__
+
+The damage dice for this spell increase by one size (for example, from 3d6 to 3d8).
+
+__Epic Feat__
+
+This spell now deals half damage on a miss.
+
+##### The Final Surge (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You and each of your nearby allies each heal hit points equal to 1d6 x the number of recoveries that character has expended this day. (And no, free recoveries don’t count; this spell only counts the resources you’ve expended.)
+
+5th level spell: 1d10 x the number of recoveries.
+
+7th level spell: 2d6 x the number of recoveries.
+
+9th level spell: 2d10 x the number of recoveries.
+
+#### Twisted Path
+
+##### Tortured Scream (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Special:** When you cast the spell, you or a willing nearby ally of your choice loses 1d6 hit points.
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** 3d6 + Charisma psychic damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 6d6 damage, you or ally loses 2d6 hit points.
+
+5th level spell: 6d10 damage, you or ally loses 4d6 hit points.
+
+7th level spell: 10d10 damage, you or ally loses 6d6 hit points.
+
+9th level spell: 2d8 x 10 damage, you or ally loses 8d6 hit points.
+
+__Adventurer Feat__
+
+The spell now deals half damage on a miss.
+
+__Champion Feat__
+
+You or an ally now lose one less die of hit points (for example, 3d6 instead of 4d6).
+
+__Epic Feat__
+
+The first time each battle you miss with this spell, if the escalation die is 3+, you can reroll the attack by having you or your ally lose the same amount of hit points again.
+
+##### Trace of Corruption (1st level+)
+
+Ranged spell
+
+Daily
+
+**Target:** You or one nearby ally; the target must have a positive or conflicted relationship with a villainous icon
+
+**Effect:** The target rolls a save against each save ends effect affecting it. Then the target can heal using a recovery from a nearby ally (target’s choice, even if that ally isn’t willing).
+
+##### Evil Touch (1st level+)
+
+Close-quarters spell
+
+At-Will
+
+**Target:** One enemy engaged with you
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d10 + Charisma negative energy damage.
+
+**Natural Even Hit:** As a hit, plus you gain 5 temporary hit points if the target drops to 0 hp during the battle.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d10 damage, 8 temporary hit points.
+
+5th level spell: 5d10 damage, 10 temporary hit points.
+
+7th level spell: 7d10 damage, 15 temporary hit points.
+
+9th level spell: 9d10 damage, 25 temporary hit points.
+
+__Adventurer Feat__
+
+This spell now deals half damage on a miss.
+
+__Champion Feat__
+
+When the target drops to 0 hp, instead of gaining temporary hit points, you can choose to deal that amount of negative energy damage to one nearby enemy as a free action.
+
+__Epic Feat__
+
+This spell can now target a nearby enemy.
+
+##### Unsummoning (7th level+)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby non-undead enemy that the GM hasn’t given a proper name, or that doesn’t play a key role in the current storyline
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** The target is sent elsewhere, possibly to a location that’s close enough for the PCs to have to deal with it in a subsequent battle. It might also go somewhere “interesting.”
+
+Replace the target with the GM’s choice of an undamaged and hostile undead creature that is one level lower than the original target. If the target was a large or double-strength creature, the replacement must be large or double-strength, or perhaps two normal undead instead of one show up. Ditto for huge/triple-strength targets. Therefore you’re only slightly reducing the raw power of the opposition; the advantage of using the spell is that you’re getting rid of an enemy you match up badly against and dropping the level of the opposition by one. The disadvantage, of course, is that you’ll probably have to face that enemy again.
+
+**Miss:** 7d10 + Charisma psychic damage.
+
+9th level spell: 8d10 + Charisma psychic damage on a miss.
+
+__Champion Feat__
+
+This spell can now also target an entire mob of mooks. If the attack hits, replace them with a mob of undead mooks that is one level lower.
+
+__Epic Feat__
+
+You don’t expend the spell when you miss with it.
+
+##### Holy Spark (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d8 + Charisma holy damage, and one nearby ally gains 3 temporary hit points.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d8 damage, 5 temporary hit points.
+
+5th level spell: 5d8 damage, 8 temporary hit points.
+
+7th level spell: 7d8 damage, 10 temporary hit points.
+
+9th level spell: 9d8 damage, 15 temporary hit points.
+
+__Adventurer Feat__
+
+When you miss with the spell, one of your nearby allies now gains the temporary hit points.
+
+__Champion Feat__
+
+This spell now deals half damage on a miss.
+
+__Epic Feat__
+
+You can now target a faraway enemy with this spell. In addition, the spell’s damage dice increase by one size from d8s to d10s.
+
+##### Temple Bells (1st level+)
+
+Ranged spell
+
+Daily
+
+**Targets:** You and each nearby ally that has 10 hp or fewer
+
+**Effect:** The target can heal using a recovery.
+
+3rd level spell: Target with 20 hp or fewer.
+
+5th level spell: Target with 40 hp or fewer.
+
+7th level spell: Target with 60 hp or fewer.
+
+9th level spell: Target with 100 hp or fewer.
+
+__Adventurer Feat__
+
+One target that heals can also roll a save against a save ends effect.
+
+__Champion Feat__
+
+The recovery is now free.
+
+__Epic Feat__
+
+Add 50 hp to the hit point threshold for targets that can be affected.
+
+##### Shadow Dance (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Targets:** Two nearby creatures, enemies or allies (including you)
+
+**Effect:** The targets teleport and swap places. Each teleported enemy takes 1d6 damage. You and your allies don’t take damage from teleporting.
+
+3rd level spell: 2d6 damage.
+
+5th level spell: 2d10 damage.
+
+7th level spell: 3d12 damage.
+
+9th level spell: 4d12 damage.
+
+__Adventurer Feat__
+
+Once per day, one or more targets of the spell can be faraway.
+
+__Champion Feat__
+
+The damage increases by one die (for example, 2d10 becomes 3d10).
+
+__Epic Feat__
+
+The spell can now target up to three nearby creatures.
+
+##### Step into Shadow (3rd level+)
+
+Close-quarters spell
+
+Once per battle
+
+**Effect:** Remove yourself from the battle (you can’t be targeted by attacks or effects while in the shadows). At the start of your next turn, return to the battle nearby your previous location and roll a d6 to determine a random benefit you gain from coming out of the shadows.
+
+_1–4:_ You can heal using a recovery.
+
+_5+:_ You deal double damage to the first target you hit with a chaos mage spell this turn.
+
+__Champion Feat__
+
+You can choose to add +1 to the d6 roll after seeing it.
+
+__Epic Feat__
+
+If you roll 6+, you gain both effects.
+
+##### Twisted beam (1st level+)
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Natural Even Hit:** 1d6 + Charisma fire damage.
+
+**Natural Odd Hit:** Lightning damage equal to half the damage from a natural even hit, and you can roll another _twisted beam_ attack against an enemy you haven’t targeted with it this turn.
+
+**Natural Even Miss:** 3 ongoing acid damage.
+
+3rd level spell: 3d6 damage, 6 ongoing damage.
+
+5th level spell: 5d6 damage, 9 ongoing damage.
+
+7th level spell: 7d8 damage, 12 ongoing damage.
+
+9th level spell: 9d8 damage, 18 ongoing damage.
+
+__Adventurer Feat__
+
+This spell can now target faraway enemies.
+
+__Champion Feat__
+
+A natural odd miss now deals half natural even hit damage.
+
+__Epic Feat__
+
+The first save against the ongoing damage from a natural even miss is a hard save (16+). The second and subsequent saves are normal.
+
+##### Ancient Scales (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** Until the end of the battle, you have _flight_ while the escalation die is even. While the escalation die is odd, you can cast _twisted beam_ once during your turn as a quick action.

--- a/Classes/Chaos Mage.md
+++ b/Classes/Chaos Mage.md
@@ -10,11 +10,11 @@ updated:: 2023-05-03
 
 # Chaos Mage
 
-### Ability Scores
+## Ability Scores
 
 Chaos Mages gain a +2 class bonus to Intelligence or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
 
-### Backgrounds
+## Backgrounds
 
 Possible backgrounds include: 
 - Blossoming witch
@@ -27,15 +27,15 @@ Possible backgrounds include:
 - Wandering musician
 - Hero from another world
 
-### Gear
+## Gear
 
 At 1st level, chaos mages start with adventuring clothes, a simple dagger (or a uniquely weird but similarly powerful weapon befitting to their background), and any other minor (and unusual) elements of gear their backgrounds suggest.
 
-#### Gold Pieces
+### Gold Pieces
 
 Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
 
-### Armor
+## Armor
 
 | __Armor Type__ | __Base AC__ | __Atk Penalty__ |
 | ---------- | ------- | ----------- |
@@ -44,7 +44,7 @@ Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
 | Heavy      | 11      | -2          |
 | Shield     | +1      | -2          |
 
-### Melee Weapons
+## Melee Weapons
 
 |                  | __One-Handed__                   | __Two-Handed__            |
 | ---------------- | -------------------------------- | ------------------------- |
@@ -52,7 +52,7 @@ Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
 | Light or Simple  | 1d6 (-2 atk) axe, shortsword     | 1d8 (-4 atk) spear        |
 | Heavy or Martial | 1d8 (-5 atk) scimitar, warhammer | 1d10 (-6 atk) greatsword |
 
-### Ranged Weapons
+## Ranged Weapons
 
 |                  | __Thrown__           | __Crossbow__                | __Bow__               |
 | ---------------- | -------------------- | --------------------------- | --------------------- |
@@ -60,7 +60,7 @@ Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
 | Light or Simple  | 1d6 (-2 atk) javelin | 1d6 (-1 atk) light crossbow | 1d6 (-2 atk) shortbow |
 | Heavy or Martial | -                    | 1d8 (-4 atk) heavy crossbow | 1d8 (-5 atk) longbow           |
 
-## Level Progression
+# Level Progression
 
 | Chaos Mage Level   | Total Hit Points           | Total Feats                    | Daily Spells (M) | Once-per-Battle Spells (M) | Spell Level (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
 |--------------------|----------------------------|--------------------------------|------------------|----------------------------|-----------------|--------------------------|---------------------------------|
@@ -80,7 +80,7 @@ Chaos Mages may start with either 25 gp or 1d6 x 10 gp.
 (M): Indicates columns in which multiclass characters lag one level behind.
 Note: Although not listed on the table, this class gets three talents. It does not get more at higher levels.
 
-## Stats
+# Stats
 
 | Ability Bonus                        | +2 Intelligence or Charisma (different from racial bonus)    |
 |--------------------------------------|--------------------------------------------------------------|
@@ -96,9 +96,9 @@ Note: Although not listed on the table, this class gets three talents. It does n
 | Icon Relationships                   | 3                                                            |
 | Talents                              | 1 per Level                                                  |
 
-## Basic Attacks
+# Basic Attacks
 
-### Melee Attack
+## Melee Attack
 
 At-Will
 **Target:** One enemy
@@ -106,7 +106,7 @@ At-Will
 **Hit:** WEAPON + Strength damage
 **Miss:** —
 
-### Ranged Attack
+## Ranged Attack
 
 At-Will
 **Target:** One enemy
@@ -114,7 +114,7 @@ At-Will
 **Hit:** WEAPON + Dexterity damage
 **Miss:** —
 
-## Class Features
+# Class Features
 
 Chaos mages use arcane implements, such as wands and staffs, to improve their attacks. Unlike wizards and clerics, chaos mages don’t choose the spells they know. Instead, a chaos mage of a given level can access all the spells in a category that are their level or lower.
 
@@ -122,7 +122,7 @@ The category of spell you’ll cast on your turn is randomly decided, but you ge
 
 Chaos mages are not allowed to cast rituals.
 
-### Chaos Magic
+## Chaos Magic
 Chaos magic has three main categories of spells: attack, defense, and iconic.
 
 Since the category of magic spells you’ll cast is randomly chosen, you’ll need 6 “stones” (gems, beads, poker chips, or whatever you like) of three different colors—two stones for each color. You’ll also need a bag (or cup) to put them in and draw them from. Put two of each color into the bag, then assign one color to attack, one color to defense, and the last color to iconic.
@@ -215,17 +215,17 @@ __High Weirdness Table__
 | 99    | Roll twice more on this table. If you wish you can ignore one of the rolled results but must stick with the other. If you roll the same result twice, you get that weirdness just once.                                                                                                                                                                                                                                         |
 | 100   | You gain an extra standard action during the next turn after this weirdness goes into effect.                                                                                                                                                                                                                                                                                                                                   |
 
-## Class Talents
+# Class Talents
 
 Choose three of the following class talents.
 
-### Warp Talents
+## Warp Talents
 
 There are three separate Warp talents that you may choose from. They provide random powers or features that surface unpredictably during battles (and perhaps during non-combat moments of high tension).
 
 If a warp talent gives you access to a spell from another class, associate it with chaos magic’s attack category or defense category. You can then cast it if that spell type comes up for you.
 
-#### Attacking Warp
+### Attacking Warp
 
 Your magic provides you with a random warp effect when the next spell you cast will be an attack spell. This talent works best for chaos mages with a high Dexterity.
 
@@ -249,7 +249,7 @@ While you are flying due to any effect, you gain a bonus to disengage checks equ
 __Epic Feat__
 When one of your spells or powers lets you teleport to a nearby location, you can instead teleport to a faraway location you can see.
 
-#### Defensive Warp
+### Defensive Warp
 
 Your magic provides you with a random warp effect when the next spell you cast will be a defense spell. This talent works best for chaos mages with a high Wisdom.
 
@@ -273,7 +273,7 @@ While you are at maximum hit points, you gain a +1 bonus to all defenses.
 __Epic Feat__
 When an attacker rerolls an attack against you, it takes an attack penalty equal to your Wisdom modifier.
 
-#### Iconic Warp
+### Iconic Warp
 
 Your magic provides you with a random warp effect when the next spell you cast will be an iconic spell. This talent works best for chaos mages with a high Intelligence.
 
@@ -297,7 +297,7 @@ When you roll a natural 18–20 on a save, a nearby ally of your choice can roll
 __Epic Feat__
 When you roll a natural 20 with an attack, the critical hit range of your attacks expands by 2 until the end of the battle (cumulative).
 
-### Separate Existence
+## Separate Existence
 
 You are ever-so-slightly detached from normal physical reality. Play the story side of that as you like; the game mechanics side is that you can cast ranged spells while engaged with enemies without taking opportunity attacks.
 
@@ -307,7 +307,7 @@ While you have an _air_ or _void_ warp effect active, you take no damage from mi
 __Champion Feat__
 When you teleport, you can heal using a recovery.
 
-### Stench of Necromancy
+## Stench of Necromancy
 
 You gain a random spell from the necromancer class. Whenever you take a full heal-up, randomly choose a necromancer spell of the highest level you can cast. For the rest of the day, you know this necromancer spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
 
@@ -322,7 +322,7 @@ While you have an _earth_ or _metal_ warp effect active, when an enemy in the ba
 __Epic Feat__
 If you don’t like the first random necromancer spell you select for the day, you can determine another random necromancer spell. You’re stuck with the second one.
 
-### Touch of Wizardry
+## Touch of Wizardry
 
 You gain a random spell from the wizard class. Whenever you take a full heal-up, randomly choose a wizard spell of the highest level you can cast. For the rest of the day, you know this wizard spell and can cast it according to its normal usage pattern—at-will, cyclic, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
 
@@ -337,7 +337,7 @@ You gain a single daily use of the wizard’s _utility spell_, cast at your leve
 __Epic Feat__
 If you don’t like the first random wizard spell you select for the day, you can determine another random wizard spell. You’re stuck with the second one.
 
-### Trace of the Divine
+## Trace of the Divine
 
 You gain a random spell from the cleric class. Whenever you take a full heal-up, randomly choose a cleric spell of the highest level you can cast. For the rest of the day, you know this cleric spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
 
@@ -352,7 +352,7 @@ While you have an _air_ or _water_ warp effect active, when you heal using a rec
 __Epic Feat__
 In addition to the random invocation you gain at the start of the day, you also get the talent/domain powers that go with it.
 
-### Whiff of Sorcery
+## Whiff of Sorcery
 
 You gain a random spell from the sorcerer class. Whenever you take a full heal-up, randomly choose a sorcerer spell of the highest level you can cast. For the rest of the day, you know this sorcerer spell and can cast it according to its normal usage pattern—at-will, once per battle, recharge, or daily—when that option comes up during your chaos mage spellcasting sequence.
 
@@ -365,9 +365,9 @@ While you have an _air_ or _fire_ warp effect active, add fire damage equal to y
 __Epic Feat__
 If you don’t like the first random sorcerer spell you select for the day, you can determine another random sorcerer spell. You’re stuck with the second one.
 
-## Attack Spells (1st Level+)
+# Attack Spells (1st Level+)
 
-#### Force Tentacle
+## Force Tentacle
 
 Ranged spell
 
@@ -401,7 +401,7 @@ __Epic Feat__
 
 One battle per day, you can deal half damage on a natural even miss with this spell.
 
-#### Chaos Ray
+## Chaos Ray
 
 Ranged spell
 
@@ -425,7 +425,7 @@ Once per battle
 
 9th level spell 8d10 damage: 5d12 damage on a miss.
 
-#### Blarrrrgh!
+## Blarrrrgh!
 
 Ranged spell
 
@@ -454,9 +454,9 @@ Daily
 
 9th level spell: 2d8 x 10 damage.
 
-### Defense Spells (1st Level+)
+# Defense Spells (1st Level+)
 
-#### Chaos Blessing
+## Chaos Blessing
 
 Close-quarters spell
 
@@ -492,7 +492,7 @@ __Epic Feat__
 
 The damage dice for the _aura/tentacles_ effect increase by one size (for example, d8s to d10s).
 
-#### Warped Healing
+## Warped Healing
 
 Close-quarters spell
 
@@ -510,15 +510,15 @@ Once per battle
 
 9th level spell: 70 temporary hit points.
 
-### Iconic Spells & Feats
+# Iconic Spells & Feats
 
 In setting up your game universe, you should have a set of icons. Distribute them more or less evenly into the spell groups below according to the theme that matches best (Blood of Warriors, Light of the High Ones, Twisted Path). When the chaos mage rolls a particular icon, they can choose any spell associate that that icon’s group of spells.
 
 Multiple icons should belong to each group. Each group should have at-will spells and at least one per-battle and daily spell.
 
-#### Blood of Warriors
+## Blood of Warriors
 
-##### Castigation (1st level+)
+### Castigation (1st level+)
 
 Close-quarters spell
 
@@ -554,7 +554,7 @@ __Epic Feat__
 
 The spell now deals half damage on a miss.
 
-##### Terribly Spiky Armor (3rd level+)
+### Terribly Spiky Armor (3rd level+)
 
 Ranged spell
 
@@ -568,7 +568,7 @@ Daily
 
 9th level spell: 7d10 damage.
 
-##### Yours! (1st level+)
+### Yours! (1st level+)
 
 Ranged spell
 
@@ -594,7 +594,7 @@ __Epic Feat__
 
 When the target heals using a recovery, it adds hit points equal to 1d10 x the escalation die to that healing.
 
-##### Ours! (1st level+)
+### Ours! (1st level+)
 
 Ranged spell
 
@@ -604,7 +604,7 @@ Daily
 
 **Effect:** The target can heal using a free recovery, adding hit points equal to 1d6 x the escalation die to that healing. Unless you or the target is a dwarf, randomly choose one of the target’s true magic items. You actively gain that item’s quirk until the end of the day.
 
-##### Fiery Claw (1st level+)
+### Fiery Claw (1st level+)
 
 Ranged spell
 
@@ -640,7 +640,7 @@ __Epic Feat__
 
 This spell now deals half damage on a miss.
 
-##### Final Wrath (5th level+)
+### Final Wrath (5th level+)
 
 Ranged spell
 
@@ -668,7 +668,7 @@ __Epic Feat__
 
 This spell now targets 2d3 enemies in a group.
 
-##### War Drums (1st level+)
+### War Drums (1st level+)
 
 Ranged spell
 
@@ -696,7 +696,7 @@ __Epic Feat__
 
 When this spell’s effect deals the extra damage, you can roll a hard save (16+). If you succeed, the _war drums_ keep beating and the effect extends to the next natural odd hit this battle! (And so on if you keep succeeding.)
 
-##### Savage Endings (3rd level+)
+### Savage Endings (3rd level+)
 
 Ranged spell
 
@@ -724,9 +724,9 @@ __Epic Feat__
 
 When you drop one or more non-mook creatures to 0 hp with this spell, you can heal using a free recovery.
 
-#### Light of the High Ones
+## Light of the High Ones
 
-##### Silver Arrows (1st level+)
+### Silver Arrows (1st level+)
 
 Ranged spell
 
@@ -756,7 +756,7 @@ __Epic Feat__
 
 This spell now targets a number of nearby or faraway enemies equal to the escalation die.
 
-##### Cascading Power (5th level+)
+### Cascading Power (5th level+)
 
 Ranged spell
 
@@ -772,7 +772,7 @@ After the damage, roll the escalation die and use the new result.
 
 9th level spell: Damage equal to 2d12 x the escalation die.
 
-##### Shards of Magic (1st level+)
+### Shards of Magic (1st level+)
 
 Ranged spell
 
@@ -808,7 +808,7 @@ __Epic Feat__
 
 A natural even miss now allows you to teleport to a faraway location you can see as a free action.
 
-##### Coronation (3rd level+)
+### Coronation (3rd level+)
 
 Close-quarters spell
 
@@ -828,7 +828,7 @@ __Epic Feat__
 
 When you make a natural even roll with a _coronation_ attack, you can have the target become confused (save ends) instead of taking damage.
 
-##### Bolt and Thunder (1st level+)
+### Bolt and Thunder (1st level+)
 
 Ranged spell
 
@@ -860,7 +860,7 @@ __Epic Feat__
 
 This spell now deals half damage on a miss.
 
-##### The Final Surge (3rd level+)
+### The Final Surge (3rd level+)
 
 Ranged spell
 
@@ -874,9 +874,9 @@ Daily
 
 9th level spell: 2d10 x the number of recoveries.
 
-#### Twisted Path
+## Twisted Path
 
-##### Tortured Scream (1st level+)
+### Tortured Scream (1st level+)
 
 Ranged spell
 
@@ -912,7 +912,7 @@ __Epic Feat__
 
 The first time each battle you miss with this spell, if the escalation die is 3+, you can reroll the attack by having you or your ally lose the same amount of hit points again.
 
-##### Trace of Corruption (1st level+)
+### Trace of Corruption (1st level+)
 
 Ranged spell
 
@@ -922,7 +922,7 @@ Daily
 
 **Effect:** The target rolls a save against each save ends effect affecting it. Then the target can heal using a recovery from a nearby ally (target’s choice, even if that ally isn’t willing).
 
-##### Evil Touch (1st level+)
+### Evil Touch (1st level+)
 
 Close-quarters spell
 
@@ -958,7 +958,7 @@ __Epic Feat__
 
 This spell can now target a nearby enemy.
 
-##### Unsummoning (7th level+)
+### Unsummoning (7th level+)
 
 Ranged spell
 
@@ -984,7 +984,7 @@ __Epic Feat__
 
 You don’t expend the spell when you miss with it.
 
-##### Holy Spark (1st level+)
+### Holy Spark (1st level+)
 
 Ranged spell
 
@@ -1018,7 +1018,7 @@ __Epic Feat__
 
 You can now target a faraway enemy with this spell. In addition, the spell’s damage dice increase by one size from d8s to d10s.
 
-##### Temple Bells (1st level+)
+### Temple Bells (1st level+)
 
 Ranged spell
 
@@ -1048,7 +1048,7 @@ __Epic Feat__
 
 Add 50 hp to the hit point threshold for targets that can be affected.
 
-##### Shadow Dance (1st level+)
+### Shadow Dance (1st level+)
 
 Ranged spell
 
@@ -1078,7 +1078,7 @@ __Epic Feat__
 
 The spell can now target up to three nearby creatures.
 
-##### Step into Shadow (3rd level+)
+### Step into Shadow (3rd level+)
 
 Close-quarters spell
 
@@ -1098,7 +1098,7 @@ __Epic Feat__
 
 If you roll 6+, you gain both effects.
 
-##### Twisted beam (1st level+)
+### Twisted beam (1st level+)
 
 Ranged spell
 
@@ -1134,7 +1134,7 @@ __Epic Feat__
 
 The first save against the ongoing damage from a natural even miss is a hard save (16+). The second and subsequent saves are normal.
 
-##### Ancient Scales (3rd level+)
+### Ancient Scales (3rd level+)
 
 Ranged spell
 

--- a/Classes/Cleric.md
+++ b/Classes/Cleric.md
@@ -1,0 +1,746 @@
+---
+aliases: [Cleric]
+created: 2023-05-04
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Cleric]
+updated:: 2023-05-04
+---
+
+# Cleric
+
+## Ability Scores
+
+Clerics gain a +2 class bonus to Wisdom or Strength, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: healer, archivist, military chaplain, temple guard, bartender, reformed thief, dwarven hierophant, initiate, and bishop.
+
+## Gear
+
+At 1st level, a cleric starts with a melee weapon, decent armor, a holy symbol, and other minor possessions suggested by their backgrounds. They might even have a crossbow.
+
+### Gold Pieces
+
+Clerics may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 12      | —           |
+| Heavy      | 14      | —           |
+| Shield     | 1       | —           |
+  
+
+### Melee Weapons
+
+|                  | One-Handed                        | Two-Handed                           |
+| ---------------- | --------------------------------- | ------------------------------------ |
+| Small            | 1d4 dagger                        | 1d6 club                             |
+| Light or Simple  | 1d6 mace, shortsword              | 1d8 spear                            |
+| Heavy or Martial | 1d8 (-2 atk) longsword, warhammer | 1d10 (–2 atk) greatsword, dire flail |
+| Shield           | 1                                 | —                                    |
+
+### Ranged Weapons
+
+|                  | __Thrown__       | __Crossbow__                | __Bow__               |
+| ---------------- | ---------------- | --------------------------- | --------------------- |
+| Small            | 1d4 dagger       | 1d4 hand crossbow           | -                     |
+| Light or Simple  | 1d6 javelin, axe | 1d6 light crossbow          | 1d6 (-2 atk) shortbow |
+| Heavy or Martial | -                | 1d8 (-1 atk) heavy crossbow | 1d8 (-5 atk) longbow  |
+
+## Level Progression
+
+| Cleric Level       | Total Hit Points           | Total Feats                     | 1st level spell (M) | 3rd level spell (M) | 5th level spell (M) | 7th level spell (M) | 9th level spell (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|---------------------------------|---------------------|---------------------|---------------------|---------------------|---------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                    | 4                   | —                   | —                   | —                   | —                   | Not affected             | ability modifier                |
+| Level 1            | (7 + CON mod) x 3          | 1 adventurer                    | 4                   | —                   | —                   | —                   | —                   | —                        | ability modifier                |
+| Level 2            | (7 + CON mod) x 4          | 2 adventurer                    | 5                   | —                   | —                   | —                   | —                   | —                        | ability modifier                |
+| Level 3            | (7 + CON mod) x 5          | 3 adventurer                    | 2                   | 3                   | —                   | —                   | —                   | —                        | ability modifier                |
+| Level 4            | (7 + CON mod) x 6          | 4 adventurer                    | 1                   | 5                   | —                   | —                   | —                   | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (7 + CON mod) x 8          | 4 adventurer 1 champion         | —                   | 2                   | 4                   | —                   | —                   | —                        | 2 x ability modifier            |
+| Level 6            | (7 + CON mod) x 10         | 4 adventurer 2 champion         | —                   | 1                   | 6                   | —                   | —                   | —                        | 2 x ability modifier            |
+| Level 7            | (7 + CON mod) x 12         | 4 adventurer 3 champion         | —                   | —                   | 2                   | 5                   | —                   | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (7 + CON mod) x 16         | 4 adventurer 3 champion 1 epic  | —                   | —                   | 1                   | 7                   | —                   | —                        | 3 x ability modifier            |
+| Level 9            | (7 + CON mod) x 20         | 4 adventurer 3 champion 2 epic  | —                   | —                   | —                   | 2                   | 6                   | —                        | 3 x ability modifier            |
+| Level 10           | (7 + CON mod) x 24         | 4 adventurer 3 champion 3 epic  | —                   | —                   | —                   | 1                   | 8                   | +1 to 3 abilities        | 3 x ability modifier            |
+Although not listed on the table, this class gets three talents. It does not gain more at higher levels.
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+| Ability Bonus                        | +2 Strength or Wisdom (different from racial bonus)          |
+|--------------------------------------|--------------------------------------------------------------|
+| Initiative                           | Dex mod + Level                                              |
+| Armor Class (heavy armor)            | 14 + middle mod of Con/Dex/Wis + Level                       |
+| Armor Class (shield and heavy armor) | 15 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense                     | 11 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense                       | 11 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                           | (7 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                           | 8                                                            |
+| Recovery Dice                        | (1d8 x Level) + Con mod                                      |
+| Backgrounds                          | 8 points, max 5 in any one background                        |
+| Icon Relationships                   | 3 points                                                     |
+| Talents                              | 3                                                            |
+
+## Basic Attacks
+
+### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+#### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+### Class Features
+
+All clerics have the Ritual Magic class feature. They also receive a bonus spell: _heal_.
+
+There are certain abilities specific to the cleric that can affect their powers:
+
+-   _Cast for power_ and _cast for broad effect:_ The spell can be used one of two ways—either as a more powerful effect on one target (power) or as a weaker effect on multiple targets (broad). Spells cast for power cannot target the caster. Spells cast for broad effect can.
+    
+-   _Free recovery_: The cleric can recover hit points as if they were using a recovery (without actually spending the recovery).
+    
+-   _Heal using a recovery_: The character targeted with a healing effect uses one of their recoveries and rolls their own recovery dice.
+    
+-   _Invocation_: A quick action that offers advantages in battle. It can be made once a day. More than one cleric in a party cannot use the same invocation during a battle.
+    
+
+#### Heal
+
+Close-quarters spell
+
+**Special:** You can use this spell twice per battle.
+
+Quick action to cast (1/round)
+
+**Target:** You or one ally you are next to
+
+**Effect:** The target can heal using a recovery.
+
+##### Adventurer Feat
+
+The target can now be a nearby ally instead of an ally you are next to.
+
+##### Champion Feat
+
+If the target of your heal spell is an ally with 0 hp or below, that ally also adds hit points equal to 1d10 x your Charisma modifier to the recovery.
+
+##### Epic Feat
+
+When you cast _heal_ on an ally you are next to, that ally adds +30 hp to the recovery.
+
+#### Ritual Magic
+
+Clerics can cast their spells as rituals. (See Rituals.)
+
+### Class Talents
+
+Choose three cleric talents/domains. Each talent/domain provides an ability that can be improved by feats. It also provides an invocation you can use as a quick action once per day, per battle, per party.
+
+#### Domain: Healing
+
+When you cast a spell that lets you or an ally heal using a recovery, the target also adds hit points equal to double your level to the recovery.
+
+**Invocation of Healing:** This battle, you gain an additional use of the _heal_ spell. The first _heal_ spell you cast after using this invocation allows the target to heal using a free recovery instead of spending a recovery.
+
+##### Adventurer Feat
+
+When you cast a spell that allows an ally to heal using a recovery, you can let them use one of your recoveries instead. (If you also have the Protection/Community domain, any nearby ally can expend the recovery instead of you.)
+
+##### Champion Feat
+
+The _invocation of healing_ gives you two additional uses of _heal_ this battle instead of only one.
+
+##### Epic Feat
+
+Increase the additional hit points the target heals to triple your level.
+
+#### Domain: Justice/Vengeance
+
+Once per turn when an enemy scores a critical hit against you or a nearby ally, or drops you or a nearby ally to 0 hp or below, you gain an attack-reroll blessing. Immediately choose a nearby ally and give them the blessing as a free action.
+
+An ally with this blessing can use it to reroll an attack as a free action this battle. An ally can only have one such blessing on them at a time.
+
+**Invocation of Justice/Vengeance:** This battle, add double your level to the miss damage of your attacks and the attacks of your nearby allies. (For example, your basic melee attack as a cleric will deal triple your level as miss damage while this invocation is active.)
+
+##### Adventurer Feat
+
+You can take the attack-reroll blessing yourself.
+
+##### Champion Feat
+
+When you gain an attack-reroll blessing to distribute, you gain two blessings to distribute instead.
+
+##### Epic Feat
+
+Attacks rolls from your reroll blessings gain a +4 bonus.
+
+#### Domain: Knowledge/Lore
+
+You gain 4 additional background points that must be used somehow in relation to knowledge or lore.
+
+**Invocation of Knowledge/Lore:** You must use this invocation during your first round of a battle. When you do, you get a quick glimpse of the battle’s future. Roll a d6; as a free action at any point after the escalation die equals the number you rolled, you can allow one of your allies to reroll a single attack roll with a +2 bonus thanks to your vision of this future.
+
+##### Adventurer Feat
+
+Once per day, you can change one of your skill checks involving knowledge to a natural 20 instead. Interpret the word “knowledge” as loosely as your GM allows. GMs, be generous.
+
+##### Champion Feat
+
+You now roll a d4 for the invocation, not a d6.
+
+##### Epic Feat
+
+You gain a different positive relationship point each day with a random icon, purely because the icon has realized you know something they need to know. It changes every day and it might contradict your usual icon relationships.
+
+#### Domain: Life/Death
+
+You and your nearby allies gain a +1 bonus to death saves.
+
+**Invocation of Life/Death:** This battle, you and each of your allies can each separately add the escalation die to a single save made by that character. In addition, you and your allies do not die from hit point damage when your negative hit points equal half your normal hit points. Instead, you die when your negative hit points equal your full hit points.
+
+##### Adventurer Feat
+
+The death save bonus increases to +2.
+
+##### Champion Feat
+
+Each battle, the first time an ally near you becomes staggered, that ally immediately heals hit points equal to twice your level.
+
+##### Epic Feat
+
+Your first use of the _resurrection_ spell is free, and doesn’t count against your total.
+
+#### Domain: Love/Beauty
+
+Once per level, you can generate a one-point conflicted relationship with a heroic or ambiguous icon you do not already have a relationship with. The relationship point remains with you until you gain a level, and then it’s time for another one-level relationship.
+
+##### Champion Feat
+
+You gain two points in the relationship instead.
+
+**Invocation of Love/Beauty:** As a free action, at some dramatic moment, you or an ally of your choice can roll for one icon relationship that might have an effect on the battle. Rolls of 5 and 6 are beneficial as usual, though the GM will have to improvise what that means in the middle of combat. The invocation’s advantage does not occur the moment you roll initiative; wait for a dramatic moment instead.
+
+#### Domain: Protection/Community
+
+Once per battle, you can affect two additional allies when you cast a spell for broad effect.
+
+##### Adventurer Feat
+
+Whenever you target one or more allies with a spell, one ally of your choice can roll a save against a save ends effect.
+
+**Invocation of Protection/Community:** This battle, critical hits against you and your nearby allies deal normal damage instead of critical damage.
+
+#### Domain: Strength
+
+You can wield heavy/martial weapons without an attack penalty.
+
+##### Adventurer Feat
+
+Once per battle, you can deal extra damage to one target you hit with a melee attack as a free action. The damage bonus is a number of d4 equal to your Strength modifier or to your level, whichever is higher.
+
+##### Champion Feat
+
+You can use d8s instead of d4s for the bonus damage dice.
+
+##### Epic Feat
+
+Once per day, you can use d20s instead of d8s for the bonus damage dice.
+
+**Invocation of Strength:** This battle, you and your nearby allies deal triple damage instead of double damage on critical hits with melee attacks.
+
+#### Domain: Sun/Anti-Undead
+
+Every attack you make deals holy damage instead of other types of damage unless you choose otherwise for a specific attack.
+
+##### Adventurer Feat
+
+If your attack already deals holy damage, it gains the following bonus damage—adventurer tier: +1 damage; champion tier: +2 damage; epic tier: +3 damage.
+
+##### Champion Feat
+
+You gain a +2 bonus to all defenses against attacks by undead.
+
+##### Epic Feat
+
+The invocation also affects your allies’ daily spells.
+
+**Invocation of Sun/Anti-Undead:** When you cast a daily cleric spell this battle, roll a d6. If you roll less than or equal to the escalation die, you regain the use of that daily spell after the battle.
+
+#### Domain: Trickery/Illusion
+
+Once per battle, as a quick action when you are engaged with an enemy, roll a d20 (your “trick die”).
+
+As a free action before the start of your next turn, give your trick die to a nearby ally or enemy who is about to make an attack roll. The trick die result becomes the natural result of their roll instead.
+
+##### Champion Feat
+
+Your trick die can be used for any one d20 roll, not just an attack.
+
+##### Epic Feat
+
+You get another trick die roll to use each battle the first time the escalation die reaches 3+.
+
+**Invocation of Trickery/Illusion:** This battle, attacks against you by enemies that moved to engage you during their turn miss on natural odd rolls.
+
+#### Domain: War/Leadership
+
+Once per turn when you make a melee attack against an enemy, hit or miss, your allies gain a +1 attack bonus against that enemy until the start of your next turn.
+
+##### Adventurer Feat
+
+The attack no longer has to be a melee attack, close and ranged attacks also work.
+
+##### Champion Feat
+
+The bonus now applies against all enemies you attack; you no longer have to single out one foe if you use a spell that attacks multiple enemies.
+
+##### Epic Feat
+
+Allies now also get a damage bonus against such enemies equal to double your Charisma modifier.
+
+**Invocation of War/Leadership:** Increase the escalation die by 1.
+
+### 1st Level Spells
+
+#### Bless
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can cast this spell for power or for broad effect.
+
+**Cast for power:** One nearby ally gains a +2 attack bonus until the end of the battle.
+
+**Cast for broad Effect:** Choose up to three nearby creatures (including you); each target gains a +1 attack bonus until the end of the battle.
+
+3rd level spell: Each target also gains 1d10 temporary hit points per point of the attack bonus.
+
+5th level spell: Each target also gains 2d10 temporary hit points instead of 1d10 per point of the attack bonus.
+
+7th level spell: All attack bonuses granted by the spell increase by +1.
+
+9th level spell: Each target also gains 3d10 temporary hit points instead of 2d10 per point of the attack bonus.
+
+#### Cure Wounds
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You or a nearby ally can heal using a free recovery.
+
+3rd level spell: The target can also roll a save against each save ends effect.
+
+5th level spell: This spell is now recharge 16+ after battle instead of daily.
+
+7th level spell: The target can heal using two free recoveries instead of one.
+
+9th level spell: This spell is now recharge 11+ instead.
+
+#### Hammer of Faith
+
+Close-quarters spell
+
+Daily
+
+**Effect:** Until the end of the battle, your basic melee attacks use d12s as their base weapon damage dice.
+
+3rd level spell: The spell now requires only a quick action to cast.
+
+5th level spell: You deal half damage on misses with basic melee attacks this battle.
+
+7th level spell: Once during the battle, you can reroll a basic melee attack.
+
+9th level spell: For the rest of the battle, change any of your basic melee attack damage dice rolls that are less than the escalation die to the escalation die value.
+
+#### Javelin of Faith
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d6 + Wisdom holy damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 8d10 damage.
+
+##### Adventurer Feat
+
+The spell also deals +1d6 damage against an undamaged target. At 5th level that increases to +2d6 damage; at 8th level it increases to +4d6 damage.
+
+##### Champion Feat
+
+You can now target a faraway enemy with the spell at a –2 attack penalty.
+
+##### Epic Feat
+
+If your natural attack roll is an 18+, make the attack a second time against a different target as a free action.
+
+#### Shield of Faith
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can cast this spell for power or for broad effect.
+
+**Cast for power:** One nearby ally gains a +2 bonus to AC this battle.
+
+**Cast for broad Effect:** Choose up to three nearby creatures (including you); each target gains a +1 bonus to AC this battle.
+
+3rd level spell: The bonus also applies to PD.
+
+5th level spell: The bonus increases by +1 while the target is staggered.
+
+7th level spell: The bonus also applies to MD.
+
+9th level spell: The bonus when cast for power increases to +4. The bonus when cast for broad effect increases to +2.
+
+#### Spirits of the Righteous
+
+Ranged spell
+
+Once per battle
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 4d6 + Wisdom holy damage, and your nearby ally with the fewest hit points gains a +4 bonus to AC until the end of your next turn.
+
+**Miss:** Your nearby ally with the fewest hit points gains a +2 bonus to AC until the end of your next turn.
+
+3rd level spell: 7d6 damage.
+
+5th level spell: 7d10 damage.
+
+7th level spell: 10d12 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+##### Champion Feat
+
+You also gain the bonus to AC until the end of your next turn on a hit.
+
+#### Turn Undead
+
+Close-quarters spell
+
+Daily
+
+**Target:** 1d4 nearby undead creatures, each with 55 hp or fewer.
+
+**Attack:** Wisdom + Charisma + Level vs. MD
+
+**Hit:** The target is dazed until end of your next turn.
+
+**Hit by 4+:** 1d10 x your level holy damage, and the target is dazed until end of your next turn.
+
+**Hit by 8+:** Against non-mooks, holy damage equal to half the target’s maximum hit points, and the target is dazed (save ends). Against mooks, the +8 result now deals 4d10 x your level holy damage.
+
+**Hit by 12+ or Natural 20:** Against non-mooks, the target is destroyed. Against mooks, the +12 result now deals 4d20 x your level holy damage
+
+3rd level spell: Target with 90 hp or fewer.
+
+5th level spell: Target with 150 hp or fewer.
+
+7th level spell: Target with 240 hp or fewer.
+
+9th level spell: Target with 400 hp or fewer.
+
+##### Adventurer Feat
+
+You can expend your daily use of _turn undead_ to gain an additional use of _heal_ in one battle.
+
+##### Champion Feat
+
+You can choose to target either demons or undead with the spell (but not both with the same casting).
+
+##### Epic Feat
+
+Increase the targeting limit by 100 hp.
+
+### 3rd Level Spells
+
+#### Cause Fear
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy with 75 hp or fewer
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** The target is weakened until the end of its next turn. On its next turn, if it’s unengaged, it does not attack and moves away from you. If it’s engaged, the target attempts to disengage as its first action, and moves away if it succeeds. If it fails, it moves away as its second action (drawing opportunity attacks). In either case, it will not attack unless it has no options for escape.
+
+**Miss:** The target hates you for having tried to scare it, and it wants to hurt you most of all, but it won’t be any stupider than usual in pursuing that goal.
+
+5th level spell: Target with 120 hp or fewer.
+
+7th level spell: Target with 190 hp or fewer.
+
+9th level spell: Target with 300 hp or fewer.
+
+#### Combat Boon
+
+Close-quarters spell
+
+At-Will
+
+**Effect:** Make a basic melee attack. If the attack hits, you or one conscious nearby ally can roll a save against a save ends effect.
+
+5th level spell: The save gains a +1 bonus.
+
+7th level spell: If the attack hits, you and your nearby conscious allies can roll a total of two saves (one per character).
+
+9th level spell: The save bonus increases to +2.
+
+##### Adventurer Feat
+
+If you score a critical hit with the combat boon attack, the subsequent save automatically succeeds.
+
+##### Champion Feat
+
+One nearby conscious ally can roll a save even if your attack misses.
+
+#### Divine Endurance
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can cast this spell for power or for broad effect.
+
+**Cast for power:** One nearby ally gains 40 temporary hit points.
+
+**Cast for broad Effect:** Choose up to three nearby creatures (including you); each target gains 20 temporary hit points.
+
+5th level spell: Temporary hp = 60/30.
+
+7th level spell: Temporary hp = 80/40.
+
+9th level spell: Temporary hp = 100/50.
+
+#### Judgment
+
+Ranged spell
+
+Daily
+
+**Targets:** All nearby staggered enemies
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 5d10 + Wisdom holy damage.
+
+**Miss:** Holy damage equal to your level.
+
+5th level spell: 8d10 damage.
+
+7th level spell: 2d6 x 10 damage.
+
+9th level spell: 2d10 x 10 damage.
+
+##### Champion Feat
+
+The spell now deals half damage on a miss.
+
+##### Epic Feat
+
+The spell is now recharge 16+ after battle instead of daily.
+
+#### Mighty Healing
+
+Ranged spell
+
+Daily
+
+**Effect:** You can cast this spell for power or for broad effect.
+
+**Cast for power:** One nearby ally can heal using a single recovery and regain double the usual number of hit points.
+
+**Cast for broad Effect:** Choose up to three nearby creatures (including you); each target can heal using a recovery.
+
+5th level spell: The spell can now target faraway allies.
+
+7th level spell: Power equals triple the usual hp for one recovery; broad equals 150% the usual hp per recovery.
+
+9th level spell: Recoveries provided by the spell are now free.
+
+##### Champion Feat
+
+This spell is now a close-quarters spell.
+
+#### Strength of the Gods
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can cast this spell for power or for broad effect.
+
+**Cast for power:** One nearby ally deals +2d8 damage with melee attacks this battle.
+
+**Cast for broad Effect:** Choose up to three nearby creatures (including you); each target deals +1d8 damage with melee attacks this battle.
+
+5th level spell: Power +4d6, Broad +2d6.
+
+7th level spell: Power +4d10, Broad +2d10.
+
+9th level spell: Power +6d10, Broad +3d10.
+
+### 5th Level Spells
+
+#### Crisis of Faith
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** For the rest of this battle, all enemies near you with 100 hp or fewer take a penalty to their Mental Defense equal to your Charisma modifier. Whenever one of those enemies misses with an attack roll, it takes holy damage equal to double your level.
+
+7th level spell: 160 hp or fewer.
+
+9th level spell: 250 hp or fewer.
+
+#### Sanctuary
+
+Close-quarters spell
+
+Daily
+
+**Effect:** Choose yourself or a nearby ally. Enemies with 100 hp or fewer cannot attack the chosen target until that creature attacks or the escalation die reaches 6+.
+
+7th level spell: 160 hp or fewer.
+
+9th level spell: 250 hp or fewer.
+
+#### Sphere of Radiance
+
+Close-quarters spell
+
+Daily
+
+**Effect:** You or one nearby ally can heal using a free recovery. Then make the following attack.
+
+**Target:** Up to two nearby enemies
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 7d8 + Charisma holy damage.
+
+**Miss:** Half damage.
+
+7th level spell: 8d12 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+### 7th Level Spells
+
+#### Circle of Protection
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** Choose a defense: AC, PD, or MD. For the rest of the battle while you are conscious, you and each ally near you gains a +1 bonus to that defense. Each enemy that misses you or one of your nearby allies with an attack against the defense you chose is hampered until the end of its next turn.
+
+9th level spell: Attacks against the chosen defense cannot score critical hits.
+
+##### Epic Feat
+
+The spell is now (recharge 16+) after battle instead of daily.
+
+#### Resurrection
+
+Ranged spell
+
+**Special:** You can cast this spell only once per level, and a limited number of times in your life. You must have most of the corpse available to cast the spell. There’s no time limit on resurrecting a dead PC, so long as you have the corpse.
+
+**Effect:** You can bring a creature back to life in more or less normal condition, with varying levels of recovery.
+
+**Limited Casting:** The first time in your life that you use the spell, you can cast it with a single standard action. Using the spell removes one of your spell slots until you gain a level. (You get one less spell per full heal-up.) The person you are resurrecting comes back at roughly half strength, e.g. expending half their recoveries, being dazed (save ends), and, for each ability, having a 50% chance that it is expended.
+
+The second time in your life you cast the spell, it takes at least three or four rounds and costs you roughly half your hit points and daily powers/spells. The person you are resurrecting comes back at something like one-quarter strength.
+
+The third time you cast the spell it has to be as a ritual. The spell chews you up and leaves you with only a few hit points, then gnaws at the person you have resurrected, who takes days to recover well enough to qualify as an adventurer or combatant.
+
+The fourth time you cast the spell it nearly kills you. The resurrection succeeds but the person you’ve resurrected is going to be a mess for a month or more, regardless of any other magic you use.
+
+The fifth time you resurrect someone, that’s the end of your story and you die. There’s only a 50% chance that the resurrection spell works on the target. You’ve used up your quota of resurrection magic. You’re not coming back via this spell, either.
+
+**Limited Resurrection:** If the target of your resurrection spell has been resurrected more times than you have cast the spell, there is a 50% chance that the experience will play out using _their_ higher number of resurrections instead of the number of times you have cast the spell.
+
+9th level spell: You no longer need to have most of the corpse to perform this spell.
+
+### 9th Level Spells
+
+#### Overworld Travel
+
+Close-quarters spell
+
+Daily
+
+**Special:** You must cast this spell outdoors. It enables you and a group of nearby allies to travel to most any location in the world that you can name.
+
+Travel takes between an hour and a day, depending on distance and the amount of effort the exerted.
+
+The destination can be in the overworld or in the land. It can’t be in the underworld.
+
+#### Prayer for Readiness
+
+Close-quarters spell
+
+Daily
+
+**Targets:** Up to 5 allies
+
+**Effect:** You utter a powerful prayer upon your comrades, giving each a special blessing. At any point later this battle, each blessed ally can acknowledge the blessing by saying “thank you” to your god, gods, or pantheon as a free action to reroll a d20 roll. That ally must take the reroll result.
+
+Note that you are giving the blessing and don’t receive it yourself.
+
+##### Epic Feat
+
+This spell is now a quick action to cast.

--- a/Classes/Commander.md
+++ b/Classes/Commander.md
@@ -1,0 +1,932 @@
+---
+aliases: [Commander]
+created: 2023-05-04
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Commander]
+updated:: 2023-05-04
+---
+
+# Commander
+
+## Ability Scores
+
+Commanders gain a +2 class bonus to Strength or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: historical re-enactor, sergeant of the city guard, street gang survivor, ex-gladiator, wilderness scout, cobbler, bouncer, exotic dancer, wargame veteran, squad leader, reformed drunk, and officer of the guard.
+
+## Gear
+
+At 1st level, commanders start with a melee weapon or two, a ranged weapon, a shield, light armor of some type (or heavy armor if they chose the Armor Skills talent), and other minor odds-and-ends suggested by their backgrounds.
+
+### Gold Pieces
+
+Commanders may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 12      | —           |
+| Heavy      | 14      | -2          |
+| Shield     | 1       | —           |
+
+### Melee Weapons
+
+|                  | One-Handed                        | Two-Handed               |
+| ---------------- | --------------------------------- | ------------------------ |
+| Small            | 1d4 dagger                        | 1d6 club                 |
+| Light or Simple  | 1d6 mace, shortsword              | 1d8 spear                |
+| Heavy or Martial | 1d8 (-2 atk) longsword, warhammer | 1d10 (–2 atk) greatsword |
+| Shield           | 1                                 | —                        |
+
+### Ranged Weapons
+
+|                  | Thrown           | Crossbow                    | Bow                  |
+| ---------------- | ---------------- | --------------------------- | -------------------- |
+| Small            | 1d4 dagger, star | 1d4 hand crossbow           | —                    |
+| Light or Simple  | 1d6 javelin      | 1d6 light crossbow          | 1d6 shortbow         |
+| Heavy or Martial | —                | 1d8 (–2 atk) heavy crossbow | 1d8 (–2 atk) longbow |
+
+### Level Progression
+
+| Commander Level    | Total Hit Points           | Total Feats                    | Class Talents (M) | Commands & Tactics (m) | Pool available (M) | Level-up Ability  | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|-------------------|------------------------|--------------------|-------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | 1 or 2 (3 total)  | 3                      | 1st level          | Not affected      | ability modifier                |
+| Level 1            | (7 + CON mod) x 3          | 1 adventurer                   | 3                 | 4                      | 1st level          |                   | ability modifier                |
+| Level 2            | (7 + CON mod) x 4          | 2 adventurer                   | 3                 | 5                      | 1st level          |                   | ability modifier                |
+| Level 3            | (7 + CON mod) x 5          | 3 adventurer                   | 3                 | 6                      | 3rd level          |                   | ability modifier                |
+| Level 4            | (7 + CON mod) x 6          | 4 adventurer                   | 3                 | 7                      | 3rd level          | +1 to 3 abilities | ability modifier                |
+| Level 5            | (7 + CON mod) x 8          | 4 adventurer 1 champion        | 4                 | 7                      | 5th level          |                   | 2 x ability modifier            |
+| Level 6            | (7 + CON mod) x 10         | 4 adventurer 2 champion        | 4                 | 8                      | 5th level          |                   | 2 x ability modifier            |
+| Level 7            | (7 + CON mod) x 12         | 4 adventurer 3 champion        | 4                 | 8                      | 7th level          | +1 to 3 abilities | 2 x ability modifier            |
+| Level 8            | (7 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 4                 | 9                      | 7th level          |                   | 3 x ability modifier            |
+| Level 9            | (7 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 4                 | 9                      | 9th level          |                   | 3 x ability modifier            |
+| Level 10           | (7 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 4                 | 10                     | 9th level          | +1 to 3 abilities | 3 x ability modifier            |
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+| Ability Bonus             | +2 Strength or Charisma (different from racial bonus)        |
+|---------------------------|--------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                              |
+| Armor Class (light armor) | 12 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense          | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense            | 12 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                | (7 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                | 8                                                            |
+| Recovery Dice             | (1d8 x Level) + Con mod                                      |
+| Backgrounds               | 8 points, max 5 in any one background                        |
+| Icon Relationships        | 3 points (4 at 5th level; 5 at 8th level)                    |
+| Talents                   | 3 (see level progression chart)                              |
+| Feats                     | 1 per Level                                                  |
+
+## Basic Attacks
+
+### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+All commanders have class features associated with _commands_ and _tactics_.
+
+Commands allow you to help your allies fight better. You issue them as interrupt actions during their turn. To issue a command, the ally must be conscious, but line of sight isn’t required.
+
+All commands are at-will powers, though they do cost command points, and are usually limited to once per round (as an interrupt). You start each battle with 1 command point and generally gain more via the two standard commander features: _Fight from the Front_ and _Weigh the Odds_. Excess command points go away at the end of the battle.
+
+Your powers also include tactics that have immediate effect during your turn. Tactics, as opposed to commands, don’t use command points. You also don’t have to wait around for an ally’s turn to use them. However, tactics don’t always recharge after a battle.
+
+You can choose the commands and tactics you want to use. A 1st-level commander starts with a total of 4 commands and tactics. An effective commander should choose a good balance of commands and tactics.
+
+### Fight from the Front
+
+When you hit with a commander melee attack during your turn, gain 1d3 command points.
+
+#### Adventurer Feat
+
+You now gain 1d4 command points when you hit with a melee attack during your turn instead of 1d3.
+
+#### Champion Feat
+
+When you make a melee attack during your turn and miss with a natural even roll, gain 1 command point.
+
+#### Epic Feat
+
+Twice per day when you hit with a melee attack, you can gain additional command points equal to double your Strength modifier.
+
+### Weigh the Odds
+
+Standard action
+
+**Effect:** Gain 1d4 command points.
+
+#### Adventurer Feat
+
+Once per day, add your Charisma modifier to the number of command points you gain when you use this action.
+
+#### Champion Feat
+
+Once per battle while the escalation die is 3+, you can gain 1d4 command points as a quick action.
+
+#### Epic Feat
+
+You now gain 1d6 command points instead of 1d4 when you use this action.
+
+## Class Talents
+
+Choose three of the following class talents. You get an additional commander talent at 5th level.
+
+### Armor Skills
+
+Unlike other commanders, you take no attack penalties for fighting in heavy armor. (As indicated on your class chart, your base AC in heavy armor is 14.)
+
+#### Adventurer Feat
+
+When an enemy misses you with a melee attack and rolls a natural 1 or 2, you gain 1 command point.
+
+#### Champion Feat
+
+Once per day as a free action when you are hit by an attack that targets AC, you can take half damage from that attack instead.
+
+#### Epic Feat
+
+Once per day as a free action, you can gain a bonus to AC equal to the _current_ escalation die until the end of the battle. (The AC bonus increases or decreases as the escalation die increases or decreases.) This bonus can’t be higher than the number of icon relationship points you have with warrior or leader icons in your game.
+
+### Battle Captain
+
+Once per battle when you have 2 or more command points left after giving a command, you can use another interrupt action on a different ally’s turn before the start of your next turn.
+
+#### Adventurer Feat
+
+You now only need to have 1 or more command points left instead of 2.
+
+#### Champion Feat
+
+You can use this talent twice per battle.
+
+#### Epic Feat
+
+You gain an additional command point at the start of each round while the escalation die is 4+.
+
+### Combat Maneuver
+
+Choose a fighter maneuver of your level or lower. You can use it like a fighter. You can also switch it for a different maneuver each time you level up.
+
+#### Adventurer Feat
+
+You gain the adventurer feat for the maneuver you chose, if any.
+
+#### Champion Feat
+
+Choose a second fighter maneuver of your level or lower to use.
+
+#### Epic Feat
+
+You gain the adventurer and champion tier feats, if any, for both your fighter maneuvers.
+
+### Destined to Lead
+
+When you roll a 5 or 6 on an icon relationship die, you gain 2 bonus command points that last until the end of the current game session, no matter what events occur due to the advantage gained with that icon.
+
+When you use one or more of these bonus command points, tell a story about how something related to the icon (or icons!) comes into play to make you a better/luckier/destined commander.
+
+#### Adventurer Feat
+
+You now gain the 2 bonus command points when you roll a 4 with an icon relationship die as well.
+
+#### Champion Feat
+
+Once per session when you roll icon relationship dice, you can reroll one die that isn’t a 5 or a 6.
+
+#### Epic Feat
+
+When you roll icon relationship dice, for each 6 you get, you and each nearby ally gain a +1 bonus to death saves until the next full heal-up.
+
+### Forceful Command
+
+When you give a command that lets an ally roll a d20 (an attack, a save, etc.), you can spend additional command points before the roll up to the escalation die value, or 1 point if the escalation die is still 0. That ally gains a +2 bonus to the roll for each point you spend this way.
+
+#### Adventurer Feat
+
+You begin each battle with 1 additional command point.
+
+#### Champion Feat
+
+Once per battle, you can use a command on a faraway ally.
+
+#### Epic Feat
+
+Once per day when you use this talent to grant an ally a bonus to a d20 roll, you can also allow that ally to reroll that roll once as a free action.
+
+### Into the Fray
+
+At the start of each battle before you and your allies roll initiative, roll a d4. A number of your allies equal to the roll gain the following benefit of your choice: a +4 bonus to initiative that battle; OR a +2 bonus to AC until the end of the first round.
+
+#### Adventurer Feat
+
+You also gain the chosen bonus.
+
+#### Champion Feat
+
+The +2 bonus to AC also applies to PD and MD.
+
+#### Epic Feat
+
+The chosen allies now gain both bonuses (+2 to all defenses for the first round and +4 to initiative this battle).
+
+### Martial Training
+
+Unlike other commanders, you don’t take a –2 attack penalty when fighting with heavy or martial weapons.
+
+#### Adventurer Feat
+
+You gain 1 command point whenever you roll a natural 19 or 20 with a melee attack.
+
+#### Champion Feat
+
+Twice per day as a free action (once per turn), you can reroll one of your melee attack rolls.
+
+#### Epic Feat
+
+Twice per day as free action (once per turn) when you hit with a melee attack, you can deal 1d10 extra damage to the target for each positive or conflicted icon relationship point you have with warrior or leader icons in your game.
+
+### Moment of Glory
+
+When you roll initiative, also roll a d4 and record the result. As a free action, you can add the result to a single attack roll made by one of your nearby allies later this battle. (It’s a free action, so you can add the result after seeing the roll.)
+
+#### Adventurer Feat
+
+You can also add the d4 result to a save or dicey-move roll made by an ally.
+
+#### Champion Feat
+
+Roll a d6 instead of a d4.
+
+#### Epic Feat
+
+In addition to the d6 you roll with initiative, roll a d4. You can also use that roll the same way, but not during the same turn you use the d6 result.
+
+### Never Say Die
+
+Once per battle when an enemy scores a critical hit against you or a nearby ally, you can increase the escalation die by 1.
+
+#### Adventurer Feat
+
+Once per day, you can use this talent twice in the same battle.
+
+#### Champion Feat
+
+When you use this talent, the target of the critical hit can heal using a recovery.
+
+#### Epic Feat
+
+When you use this talent, you and each of your nearby allies gains a +2 bonus to all defenses until the end of your next turn.
+
+### Strategist
+
+You rely on planning, teamwork, and calm execution of orders as a commander instead of charismatic presence. Any time an element of the commander class refers to Charisma, you can replace that element with a reference to Intelligence.
+
+In addition, you start every battle with 1 additional command point.
+
+#### Adventurer Feat
+
+You gain 1 additional point in a background related to military history, strategy, command, or warfare. You can use this background point to raise that background beyond the normal maximum of 5.
+
+#### Champion Feat
+
+When you roll a die to find out how many allies one of your commands or tactics targets, add +1 to the result.
+
+#### Epic Feat
+
+Once per day as a free action, you can gain a number of command points equal to your Intelligence modifier.
+
+### Sword of Victory
+
+When your melee attack drops a non-mook enemy to 0 hp, or drops three or more mooks, you gain 1 command point.
+
+#### Adventurer Feat
+
+You only have to drop 2 or more mooks instead of 3 to gain the command point.
+
+#### Champion Feat
+
+You gain 2 command points instead of 1 when you drop a non-mook enemy to 0 hp.
+
+#### Epic Feat
+
+Once per day as a quick action, you can gain command points equal to the number of icon relationship points you have with the any one icon associated with battle or victory.
+
+### Tactician
+
+You rely on perception, intuition, and common sense as a commander instead of charismatic presence. Any time an element of the commander class refers to Charisma, you can replace that element with a reference to Wisdom.
+
+In addition, one battle per day, you can reroll your initiative if you don’t like the first result. You must take the re-rolled result.
+
+#### Adventurer Feat
+
+You gain 1 additional point in a background related to military history, strategy, command, or warfare. You can use this background point to raise that background beyond the normal maximum of 5.
+
+#### Champion Feat
+
+Once per day after a battle, you can gain a bonus to all recharge rolls you make for your expended tactics equal to your Wisdom modifier.
+
+#### Epic Feat
+
+Once per day as a free action, you can choose a tactic you don’t normally possess and use it as if you did (you don’t get any feats associated with it).
+
+## 1st Level Commands
+
+### Get Out of There!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Effect:** The target can use a quick action this turn to pop free from one enemy.
+
+#### Adventurer Feat
+
+If you spend an additional command point, the target (or targets) can pop free from all enemies instead of only one enemy.
+
+#### Champion Feat
+
+If you spend an additional command point, you can now target one additional nearby ally with this command.
+
+#### Epic Feat
+
+When targets of this command are stuck, that condition ends on them.
+
+### Rally Now
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Special:** If you spend an additional command point on this command, you can target an unconscious ally with it.
+
+**Effect:** The target can rally as a free action this turn. (If it’s their second or a subsequent rally, they still need to succeed on the save.)
+
+#### Adventurer Feat
+
+The target also adds hit points equal to your Charisma modifier to the recovery. (Double your Charisma modifier at 5th level; triple it at 8th level.)
+
+#### Champion Feat
+
+When the target has to roll a save to rally, you can grant them a +2 bonus to the roll as a free action after seeing it for each additional command point you spend on the command.
+
+#### Epic Feat
+
+The target of this command also gains a +2 bonus to all defenses until the end of its next turn.
+
+### Save Now!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Effect:** The target can roll a save against a save ends effect.
+
+#### Adventurer Feat
+
+For each additional 2 command points you spend when you make the command (before the save roll), the target can roll another d20 for the save, choosing the best result.
+
+#### Champion Feat
+
+If the save fails, you gain 1 command point.
+
+#### Epic Feat
+
+Whether or not the save succeeds, the target of your command heals hit points equal to 3d10 + triple your Charisma modifier.
+
+### Try Again
+
+Interrupt action
+
+**Cost:** 2 command points
+
+**Target:** One nearby ally that made an attack roll (on that ally’s turn)
+
+**Effect:** The target can reroll the attack but must use the new result.
+
+#### Adventurer Feat
+
+If the escalation die is 3+, the target gains a bonus to the reroll equal to your Charisma modifier.
+
+#### Champion Feat
+
+If the rerolled attack scores a critical hit, you gain 1 command point.
+
+#### Epic Feat
+
+You can use this command before an ally makes an attack roll for 3 command points (instead of 2) for an entirely different effect: The target can make an additional basic attack this turn as a free action if the attack hits.
+
+### You Set Them Up, I Finish
+
+Interrupt action
+
+**Cost:** 4 command points
+
+**Target:** One nearby ally (on the ally’s turn) that hits an enemy you can see with an attack this turn
+
+**Effect:** Add your Charisma modifier to the damage dealt by your ally (double your Charisma modifier at 5th level; triple it at 8th level). In addition, during your next turn, you gain a +2 attack bonus with melee attacks against the enemy that your ally hit.
+
+#### Adventurer Feat
+
+The target ally also gains the damage bonus with any other attacks it makes against the same enemy this turn.
+
+#### Champion Feat
+
+The command now costs 3 command points to use.
+
+#### Epic Feat
+
+Your attacks that benefit from the +2 attack bonus against that enemy also add triple your Charisma modifier to your damage on a hit.
+
+## 1st Level Tactics
+
+### Basic Tactical Strike
+
+Quick action
+
+**Recharge** 11+ after battle
+
+**Target:** One nearby ally
+
+**Effect:** The target can make a basic attack as a free action.
+
+#### Adventurer Feat
+
+On a hit, the attack gains a damage bonus equal to your Charisma modifier.
+
+#### Champion Feat
+
+The target gains an attack bonus equal to your Charisma modifier with that attack.
+
+#### Epic Feat
+
+The recharge roll is now 6+.
+
+### Enforce Clarity
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Target:** One nearby ally
+
+**Effect:** One non-last gasp effect on the target ends (including effects that don’t require a save).
+
+#### Adventurer Feat
+
+The recharge roll is now 11+_**.**_
+
+#### Champion Feat
+
+You can now target one additional nearby ally with this tactic.
+
+#### Epic Feat
+
+The recharge roll is now 6+.
+
+### Just Stay Calm
+
+Quick action, when the escalation die is 2+
+
+**Recharge** 16+ after battle
+
+**Effect:** Decrease the escalation die by 1. Then 1d3 of your nearby allies can heal using a recovery.
+
+#### Adventurer Feat
+
+The tactic now affects 1d3 + 1 nearby allies.
+
+#### Champion Feat
+
+You can include yourself as one of the targets.
+
+#### Epic Feat
+
+When you use this tactic, you can spend an additional command point to avoid decreasing the escalation die.
+
+### Outmaneuver
+
+Quick action, once per round
+
+Close-quarters attack
+
+**At-Will**
+
+_Limited Use:_ You can only use this tactic when you have 0 command points.
+
+**Target:** The nearby enemy with the highest Mental Defense
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** You gain 1 command point.
+
+#### Adventurer Feat
+
+When you are engaged with one or more enemies, you can target the enemy with the highest MD you are engaged with instead of the nearest enemy.
+
+#### Champion Feat
+
+When you attack with this tactic and roll a natural even hit, you gain 2 command points instead of 1.
+
+#### Epic Feat
+
+Once per battle as a free action when you hit with this tactic, the target also takes 1d10 psychic damage for each point on the escalation die.
+
+## 3rd Level Commands
+
+### Charge!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Effect:** As a standard action this turn, the target can both move and make a basic attack.
+
+#### Adventurer Feat
+
+If you spend an additional command point, the target can use a melee attack instead of a basic attack.
+
+#### Champion Feat
+
+The target gains a bonus to the melee attack it makes from this command equal to your Charisma modifier.
+
+#### Epic Feat
+
+This turn, if the target moves to attack an enemy you are also engaged with, that enemy is vulnerable to the attack.
+
+### Hit Harder
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally who hits with an attack (on the ally’s turn)
+
+**Effect:** The target can reroll any of the damage dice. They must accept the rerolled result.
+
+#### Adventurer Feat
+
+The target gains a bonus to the damage roll equal to your Charisma modifier (double your Charisma modifier at 5th level; triple it at 8th level).
+
+#### Champion Feat
+
+You can spend an additional command point (1 max) to add another damage die of the same type to the damage roll when you reroll damage dice. (You only roll the extra damage die once.)
+
+#### Epic Feat
+
+You can also use this command as a free action (instead of as an interrupt action) when an ally hits with an opportunity attack.
+
+### You Are A Precious Snowflake!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby non-human ally using a once-per-battle racial power (on the ally’s turn)
+
+**Effect:** Roll a d20. On a 11+, the target doesn’t expend the use of its racial power and can use it again later this battle.
+
+## 3rd Level Tactics
+
+### Finish This!
+
+Quick action, when the escalation die is 4+
+
+**Recharge** 16+ after battle
+
+_Limited Use:_ You can only use this tactic when one enemy is left in the battle.
+
+**Effect:** You can spend between 1 and 3 command points. The crit range of your allies’ attacks against the remaining enemy expands by the number of command points you spent. This effect lasts until the end of the battle or until the _enemy_ scores two critical hits.
+
+#### Adventurer Feat
+
+You can now use this tactic when the escalation die is 3+.
+
+#### Champion Feat
+
+You can now use this tactic when one or two enemies are left in the battle.
+
+#### Epic Feat
+
+You can now spend between 1 and 5 command points on the effect.
+
+### Scramble
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Targets:** You and 1d3 nearby allies
+
+**Effect:** Each target can take a move action as a free action, starting with you and proceeding in the order of your choice.
+
+#### Adventurer Feat
+
+Disengage checks made using this free action gain a +5 bonus.
+
+#### Champion Feat
+
+The recharge roll is now 11+.
+
+#### Epic Feat
+
+Each target can also make a basic attack as a free action after taking the move action.
+
+### Swordwork
+
+Free action, when the escalation die is 4+
+
+**Recharge** 16+ after battle
+
+**Effect:** You can make a basic melee attack as a quick action once each turn until the end of the battle.
+
+You can’t gain command points from your Fight from the Front class feature using _swordwork_ attacks.
+
+#### Adventurer Feat
+
+You can now use this tactic when the escalation die is 3+.
+
+#### Champion Feat
+
+You can now gain command points from your Fight from the Front class feature using _swordwork_ attacks.
+
+#### Epic Feat
+
+The recharge roll is now 11+.
+
+## 5th Level Commands
+
+### Hit ’Em From Here!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Effect:** This turn, the target ally can target one faraway enemy with a power, spell, or attack that normally only targets or affects nearby enemies.
+
+#### Champion Feat
+
+The target can now be a faraway ally.
+
+#### Epic Feat
+
+The target ally’s power, spell, or attack can now target multiple faraway creatures (if it can target multiple creatures normally).
+
+### Strike Here!
+
+Interrupt action
+
+**Cost:** 4 command points
+
+**Target:** One ally engaged with an enemy you are engaged with (on the ally’s turn)
+
+**Effect:** The target can take an extra standard action this turn.
+
+#### Champion Feat
+
+This command costs 3 command points instead of 4.
+
+#### Epic Feat
+
+If the extra standard action is an attack, the crit range of that attack expands by an amount equal to the escalation die.
+
+### We’ve Got Your Back!
+
+Interrupt action
+
+**Cost:** 1 command point
+
+**Target:** One nearby confused, dazed, or weakened ally (at the start of the ally’s turn)
+
+**Effect:** Roll a d20. On a 11+, the target ignores the effects of one of those conditions (confused, dazed, weakened) this turn. On a 16+, the condition ends instead.
+
+#### Champion Feat
+
+After the first time in a round you use this command as an interrupt action, you can use it as a free action until the start of your next turn if you have the command points for the cost. You can still only use the command once per ally’s turn.
+
+#### Epic Feat
+
+Add hampered and stunned to the list of conditions the effect includes.
+
+## 5th Level Tactics
+
+### Advanced Tactical Strike
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Target:** One nearby ally
+
+**Effect:** The target can make an at-will attack as a free action.
+
+#### Champion Feat
+
+The first time you use this tactic each battle, make a recharge roll for it at the start of your next turn, adding the escalation die to the roll. The recharge roll after the battle, if any, doesn’t gain a bonus from the escalation die.
+
+#### Epic Feat
+
+The recharge roll is now 11+.
+
+### Buck Up!
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Targets:** You and 1d4 nearby allies
+
+**Effect:** Each target gains temporary hit points equal to the average number of hit points it gains when it heals using a recovery.
+
+#### Champion Feat
+
+Add twice your Charisma modifier to the temporary hit points each target gains.
+
+#### Epic Feat
+
+One of the targets can also heal using a recovery.
+
+## 7th Level Commands
+
+### Chain of Commands
+
+Free action
+
+**Cost:** 1 command point
+
+**Target:** You
+
+**Effect:** The next interrupt action you use to make a command doesn’t prevent you from using another interrupt action later in the round.
+
+### You Know What to Do!
+
+Interrupt action
+
+**Cost:** 4 command points
+
+**Target:** One nearby ally (on that ally’s turn)
+
+**Effect:** The target can take an extra standard action this turn.
+
+#### Champion Feat
+
+This command costs 3 command points instead of 4.
+
+#### Epic Feat
+
+The target also gains temporary hit points equal to 3d10 + triple your Charisma modifier.
+
+## 7th Level Tactics
+
+### Climactic Battle
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Effect:** Until the end of the battle, the escalation die becomes a d8 instead of a d6. Then roll a d20. If you roll 11+, increase the escalation die by 1.
+
+#### Champion Feat
+
+If the d20 roll is 16+, increase the escalation die by 2 instead of 1.
+
+#### Epic Feat
+
+When the escalation die reaches 8, you gain 1d6 command points and can make recharge rolls for all your tactics.
+
+### On Your Feet, Maggots!
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Targets:** Up to two allies who are staggered or at 0 hit points or below.
+
+**Effect:** The target can heal using two recoveries but is dazed until the end of its next turn.
+
+#### Champion Feat
+
+If the escalation die is 3+, there is no dazed effect.
+
+#### Epic Feat
+
+This tactic now targets up to 1d4 + 1 allies.
+
+### Saving Will
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Target:** One nearby ally
+
+**Effect:** The target gains a +5 bonus to all saves until the end of your next turn.
+
+#### Champion Feat
+
+This tactic can now be used as a free action.
+
+#### Epic Feat
+
+You can now target a faraway ally.
+
+## 9th Level Commands
+
+### Natural Command
+
+Interrupt action
+
+**Cost:** 2 command points
+
+**Target:** One nearby ally (on the ally’s turn)
+
+**Effect:** Count a natural odd roll the target rolls as natural even, or count a natural even roll the target rolls as natural odd (without actually changing the numerical result).
+
+#### Epic Feat
+
+This command costs 1 command point instead of 2 while the escalation die is 3+.
+
+### You’ll Die When I Tell You to Die!
+
+Interrupt action
+
+**Cost:** Your remaining command points
+
+**Target:** One nearby ally about to roll a death save (on the ally’s turn)
+
+**Effect:** The target gains a +2 bonus to the death save for each command point spent on this command.
+
+#### Epic Feat
+
+If the target succeeds on its death save, it can take its turn normally as if it rolled a natural 20.
+
+## 9th Level Tactics
+
+### Force a Conclusion
+
+Free action
+
+**Recharge** 16+ after battle
+
+**Effect:** If the escalation die is 2+, roll the escalation die and use the new result.
+
+#### Epic Feat
+
+You gain command points equal to the newly rolled escalation die value.
+
+### Now, Not Later
+
+Free action
+
+**Recharge** 16+ after battle
+
+**Target:** One nearby ally using a recharge power
+
+**Effect:** The target can make a recharge roll for that power immediately after using the power. (If the recharge roll fails, the target can still make a recharge roll for it after the battle.)
+
+#### Epic Feat
+
+The target gains a bonus to the recharge roll equal to your Charisma modifier.
+
+### Supreme Tactical Strike
+
+Quick action
+
+**Recharge** 16+ after battle
+
+**Target:** One nearby ally
+
+**Effect:** The target can make a standard action attack as a free action.
+
+#### Epic Feat
+
+If the attack hits, it’s a critical hit.

--- a/Classes/Druid.md
+++ b/Classes/Druid.md
@@ -1,0 +1,2471 @@
+---
+aliases: [Druid]
+created: 2023-05-04
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Druid]
+updated:: 2023-05-04
+---
+
+# Druid
+
+## Ability Scores
+
+Druids gain a +2 class bonus to Strength, Dexterity, or Wisdom, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: orc-tribe hunter/gatherer, avalanche prophet, cult zealot, river guide, tribe healer, failed shaman, wild temple priest, mystic waterfall guardian, and raised by wolverines.
+
+## Gear
+
+At 1st level, druids start with a melee weapon, light armor, possibly a staff, perhaps a bow or other ranged weapon, and other minor possessions suggested by their backgrounds.
+
+### Gold Pieces
+
+Druids may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC |
+|------------|---------|
+| None       | 10      |
+| Light      | 10*     |
+| Heavy      | 14      |
+| Shield     | 1       |
+
+### Melee Weapons
+
+|                  | One-Handed                     | Two-Handed                         |
+| ---------------- | ------------------------------ | ---------------------------------- |
+| Small            | 1d4 dagger                     | 1d6 club, staff                    |
+| Light or Simple  | 1d6 mace, axe, shell blade     | 1d8 spear                          |
+| Heavy or Martial | 1d8 (-2 atk)* warhammer, flail | 1d10 (–2 atk) dire flail, greataxe |
+| Shield           | 1                              | -2*                                |
+\*Warrior druid talent choices can change shield and one-handed weapon stats.
+
+### Ranged Weapons
+
+|                  | Thrown           | Crossbow                    | Bow                  |
+| ---------------- | ---------------- | --------------------------- | -------------------- |
+| Small            | 1d4 dagger       | 1d4 (-2 atk)hand crossbow   | —                    |
+| Light or Simple  | 1d6 javelin, axe | 1d6 (-2 atk) light crossbow | 1d6 shortbow         |
+| Heavy or Martial | —                | 1d8 (–5 atk) heavy crossbow | 1d8 (–2 atk) longbow |
+| Shield           | 1                | -2*                         | 3                    |
+
+### Level Progression
+
+| Druid Level        | Total Hit Points*          | Total Feats                    | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | Not affected             | ability modifier                |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   |                          | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   |                          | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   |                          | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        |                          | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        |                          | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic |                          | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic |                          | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | +1 to 3 abilities        | 3 x ability modifier            |
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+| Ability Bonus             | +2 Strength, Dexterity, or Wisdom (different from racial bonus) |
+|---------------------------|-----------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                                 |
+| Armor Class (light armor) | 10 + middle mod of Con/Dex/Wis + Level                          |
+| Physical Defense          | 11 + middle mod of Str/Con/Dex + Level                          |
+| Mental Defense            | 11 + middle mod of Int/Wis/Cha + Level                          |
+| Hit Points                | (6 + Con mod) x Level modifier (see level progression chart)    |
+| Recoveries                | (probably) 8                                                    |
+| Recovery Dice             | (1d6 x Level) + Con mod                                         |
+| Backgrounds               | 8 points, max 5 in any one background                           |
+| Icon Relationships        | 3 (4 at 5th level; 5 at 8th level)                              |
+| Talents                   | 3                                                               |
+| Feats                     | 1 per Level                                                     |
+
+## Basic Attacks
+
+### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength or Dexterity + Level vs. AC
+**Hit:** WEAPON + Strength or Dexterity damage
+**Miss:** Damage equal to your level
+
+### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+Druids use divine implements, such as symbols and staffs, to improve their spellcasting. They can choose up to three talents to have many useful aptitudes, or they can specialize by putting two points into one talent (and the other into another talent). A druid who chooses three separate talents is an _initiate_ in each one. Investing two points into a single talent allows the druid to become _adept_ in that talent, thereby gaining more power at the expense of options, and an _initiate_ in another talent.
+
+As a druid, you choose whether you want to use Strength or Dexterity as the ability score you will use to determine attack and damage for your basic attacks. Choosing Strength as your melee attack ability score provides one significant benefit: your recovery dice become d10s instead of the d6s used by other druids. Choosing Dexterity as your melee attack ability score works well because Dexterity already boosts your initiative and ranged weapon attacks and might help your AC.
+
+You never suffer from natural weather-related cold, heat, or exposure. You can go longer than most people without eating or drinking, but only a couple days longer.
+
+You can also talk to plants and animals. If there is useful information to gain, roll a skill check that’s appropriate for the tier. Talking to animals requires a hard DC, and plants usually require a ridiculously hard DC. A druid gains a +1 bonus when talking with animals for every talent spent on the Shifter or Animal Companion talents. A druid gains a +1 bonus when talking with plants for every talent spent on the Terrain Caster talent.
+
+### Adventurer Feat
+
+You can talk with plants and animals pretty much as often you like, and you gain a +5 bonus to any skill checks involved.
+
+## Druid Talents
+
+Each of your talents unlocks pools of spells and powers that are not available to characters who lack the talent. Druids who choose to be an adept with a talent gain additional benefits and powers in that talent.
+
+_**Animal Companion:**_ As an initiate talent, it’s based on the ranger’s Animal Companion talent, but it’s only useful in half your battles instead of all the time. If you choose to be an Animal Companion adept, your animal companion will be with you every battle and you also learn spells that make your animal companion more effective.
+
+_**Elemental Caster:**_ This talent is one of the druid’s two main spellcasting options. As an initiate talent, it grants access to a wide range of daily spells associated with air, earth, fire, and water. Becoming an Elemental Caster adept increases the number of spells you know and provides greater access to summoned elementals. As either an initiate or an adept, you can use adventurer-tier elemental mastery feats to gain at-will spell attacks.
+
+_**Shifter:**_ This talent enables you to shift your form in two ways: scout form transformations into quick-moving animals for out of combat reconnaissance, and beast form transformations into combat-ready predators. Adepts gain more benefits while fighting in beast form.
+
+_**Terrain Caster:**_ This talent is the druid’s other major spellcasting option. As an initiate, you gain access to daily spells that you can only cast in one of the eight specific types of terrain. Adepts get twice as many daily spells. Feats provide at-will spell attacks that can be used regardless of what terrain you are in.
+
+_**Warrior Druid:**_ This talent lets a druid use once-per-battle flexible attacks that enable them to fight as a serious melee combatant in humanoid form. Generally, this talent makes druids into weapon and shield users, but the talent can integrate with the Shifter talent while a druid fights in beast form.
+
+_**Wild Healer:**_ As an initiate talent, it gives you access to _regeneration_ spells and eventually a _wild heal_ spell. Adepts get enough _regeneration_ spells, _wild heal_ spells, and _greater regeneration_ spells to be a primary healer in any adventuring group.
+
+### Animal Companion
+
+You have a normal-sized animal companion that fights alongside you in battle. See Animal Companion Rules.
+
+### Elemental Caster
+
+As an elemental caster, you can summon elementals and draw on the raw magic of nature, providing many powerful daily spells. Like a wizard or cleric, you choose the Elemental Caster spells you will be able to cast after each full heal-up.
+
+You can choose as many feats as you wish from feat trees related to mastering the four elements: air, earth, fire and water. The adventurer-tier feats for the elemental masteries provide access to at-will attack spells. You cast these at-will spells at your current level or one level below (when you’re at even levels).
+
+Elemental caster initiates can cast fewer daily spells than adepts. Adepts are also able to use two different _summon elemental_ spells each day, to the initiate’s one.
+
+#### Elemental Caster Initiate Level Progression
+| Druid Level        | 1st level | 3rd level  | 5th level  | 7th level  | 9th level |
+|--------------------|-----------|------------|------------|------------|-----------|
+| Level 1 Multiclass | 1         | —          | —          | —          | —         |
+| Level 1            | 1         | —          | —          | —          | —         |
+| Level 2            | 1         | —          | —          | —          | —         |
+| Level 3            | —         | 1          | —          | —          | —         |
+| Level 4            | 1         | 1          | —          | —          | —         |
+| Level 5            | —         | 1          | 1          | —          | —         |
+| Level 6            | —         | —          | 2          | —          | —         |
+| Level 7            | —         | —          | 1          | 1          | —         |
+| Level 8            | —         | —          | 1          | 2          | —         |
+| Level 9            | —         | —          | —          | 2          | 1         |
+| Level 10           | —         | —          | —          | 1          | 2         |
+
+#### Elemental Caster Adept Level Progression
+| Druid Level        | 1st level | 3rd level  | 5th level  | 7th level  | 9th level  |
+|--------------------|-----------|------------|------------|------------|------------|
+| Level 1 Multiclass | 1         | —          | —          | —          | —          |
+| Level 1            | 1         | —          | —          | —          | —          |
+| Level 2            | 2         | —          | —          | —          | —          |
+| Level 3            | 1         | 2          | —          | —          | —          |
+| Level 4            | —         | 3          | —          | —          | —          |
+| Level 5            | —         | 2          | 2          | —          | —          |
+| Level 6            | —         | 1          | 3          | —          | —          |
+| Level 7            | —         | —          | 3          | 2          | —          |
+| Level 8            | —         | —          | 1          | 4          | —          |
+| Level 9            | —         | —          | —          | 3          | 3          |
+| Level 10           | —         | —          | —          | 2          | 4          |
+
+#### Air Mastery
+
+##### Adventurer Feat
+
+You gain the _hail hail_ spell below.
+
+##### Champion Feat
+
+All elementals you summon gain a bonus to disengage checks equal to your Strength or Dexterity modifier.
+
+##### Epic Feat
+
+The first daily Air spell you cast each day is now a recharge 16+ after battle spell for the rest of the day.
+
+##### Hail Hail
+
+Ranged spell
+
+At-Will
+
+**Target:** The nearby or faraway enemy you can see that has the most hit points
+
+**Attack:** Wisdom + Level vs. PD
+
+**Natural Even Hit:** 1d6 + Wisdom cold damage, and a different nearby enemy takes cold damage equal to your level.
+
+**Natural Odd Hit:** 1d6 + Wisdom cold damage, and each nearby mook takes 1d3 damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d6 damage, 1d6 mook damage on odd hit.
+
+5th level spell: 5d6 damage, 1d10 mook damage on odd hit.
+
+7th level spell: 5d8 damage, 2d8 mook damage on odd hit.
+
+9th level spell: 7d10 damage, 4d6 mook damage on odd hit.
+
+#### Earth Mastery
+
+##### _**Adventurer Feat**_
+
+You gain the _ripping vines_ spell below.
+
+##### _**Champion Feat**_
+
+Enemies roll two d20 when they attempt to disengage from elementals you summon, and must take the lower result.
+
+##### _**Epic Feat**_
+
+The first daily Earth spell you cast each day is now a recharge 16+ after battle spell for the rest of the day.
+
+##### _**Ripping Vines**_
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d8 + Wisdom damage.
+
+**Natural Odd Hit:** As a hit, plus ongoing damage equal to your Strength or Dexterity modifier, whichever is higher.
+
+**Crit:** As a hit, plus the target is stuck (save ends).
+
+3rd level spell: 3d6 damage.
+
+5th level spell: 5d6 damage, ongoing damage equal to double your Strength or Dexterity modifier on a natural odd hit.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d10 damage, ongoing damage equal to triple your Strength or Dexterity modifier on a natural odd hit.
+
+#### Fire Mastery
+
+##### _**Adventurer Feat**_
+
+You gain the _flame spear_ spell below.
+
+##### _**Champion Feat**_
+
+When an elemental you have summoned drops to 0 hp, one enemy engaged with it takes damage equal to your level + double your Wisdom modifier.
+
+##### _**Epic Feat**_
+
+The first daily Fire spell you cast each day is now a recharge 16+ after battle spell for the rest of the day.
+
+##### _**Flame Spear**_
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d12 + Wisdom fire damage.
+
+**Natural Odd Hit:** As a hit, plus one of your allies engaged with the target, if any, takes 1d6 fire damage.
+
+3rd level spell: 5d6 damage, 2d6 damage on odd hit.
+
+5th level spell: 5d8 damage, 2d8 damage on odd hit.
+
+7th level spell: 7d10 damage, 3d10 damage on odd hit.
+
+9th level spell: 10d10 damage, 4d6 damage on odd hit.
+
+#### Water Mastery
+
+##### _**Adventurer Feat**_
+
+You gain the _deeper waters_ spell below.
+
+##### _**Champion Feat**_
+
+Each elemental you summon gains temporary hit points equal to your level the first time each turn it rolls a natural even attack roll.
+
+##### _**Epic Feat**_
+
+The first daily Water spell you cast each day is now a recharge 16+ after battle spell for the rest of the day.
+
+##### _**Deeper Waters**_
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d10 + Wisdom damage.
+
+**Natural Even Hit:** As a hit, plus the target takes ongoing damage equal to your level or increases an already existing ongoing damage effect by your level (your choice).
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 8d10 damage.
+
+#### 1st Level Spells
+
+Spells that include the name of the elemental domain in their title, such as _earth strength_ and _faerie fire_, don’t require domain markers. Spells whose names aren’t self-explanatory are marked with their domain in parentheses.
+
+##### Earth Strength
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Targets:** One nearby ally you choose and one other random nearby ally. Both targets must be touching the ground.
+
+**Effect:** The effect depends on the target’s status.
+
+_Unstaggered target:_ The target gains a bonus to its attacks and damage equal to your Strength or Dexterity modifier until the target ends its turn staggered or until the end of the battle.
+
+_Staggered target:_ The target can heal using a recovery.
+
+3rd level spell: You can now be the chosen target.
+
+5th level spell: An unstaggered target also gains the bonus to saves.
+
+7th level spell: A staggered target can heal using a free recovery instead.
+
+9th level spell: The spell targets two random nearby allies instead of one.
+
+##### Faerie Fire
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 3d6 + Wisdom fire damage, and the target is vulnerable (hard save ends, 16+).
+
+**Miss:** Half damage, and the target is vulnerable until the end of your next turn.
+
+3rd level spell: 6d6 damage, and in addition to being vulnerable, the target can’t turn invisible or hide from you or your allies (save ends both).
+
+5th level spell: 6d10 damage, and the target also can’t teleport (save ends all).
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+##### Gust (Air)
+
+Close-quarters spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Always:** Before rolling the attack, you can attempt to disengage as a free action.
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 3d6 damage, and 5 ongoing cold damage.
+
+**Miss:** You don’t expend the spell.
+
+3rd level spell: 6d6 damage.
+
+5th level spell: 6d10 damage and 10 ongoing cold damage, and you gain _flight_ until the end of your next turn.
+
+7th level spell: 10d10 damage and 10 ongoing cold damage, and you gain _flight_ until the end of the battle.
+
+9th level spell: 2d8 x 10 damage, and 15 ongoing cold damage.
+
+##### Water Breathing
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can breathe underwater until the end of the battle, or for five minutes.
+
+3rd level spell: The spell now targets up to five nearby allies as well as you.
+
+5th level spell: The effect lasts for about five hours.
+
+7th level spell: The effect lasts for about ten hours.
+
+9th level spell: The effect lasts until your next full heal-up.
+
+#### 3rd Level Spells
+
+The 3rd level Elemental Caster spells are the four elemental summoning spells: _summon air elemental_, _summon earth elemental_, _summon fire elemental_, and _summon water elemental_. Each summoning spell summons an elemental of the same level as the spell.
+
+Summoned elementals start battles with half the hit points of standard elementals.
+
+Each elemental that’s at least 5th level has a transformation ability that greatly improves its effectiveness in battle. Free elementals transform the first time they succeed with their transformation rolls, but summoned elementals have to succeed with their transformation rolls _twice_ before their transformation takes effect.
+
+Initiates can choose only one _summon elemental_ spell each day, while adepts can choose up to two.
+
+(See Summoning Rules for the basic summoning rules.)
+
+These feats apply to the following summoning spells.
+
+##### Adventurer Feat
+
+Your summoned creatures can arrive anywhere you can see nearby, instead of needing to appear beside you.
+
+##### Champion Feat
+
+When you summon a non-mook creature, roll 2d10 and add double your Strength modifier or Dexterity modifier, whichever is higher. Your summoned creature increases its base hit points by that amount. (At 8th level, roll 3d10 and add triple the modifier.)
+
+##### Epic Feat
+
+Once per day when you heal using a recovery, a creature you summoned can heal the same amount, ignoring the usual restrictions on limited healing for summoned creatures.
+
+##### Summon Air Elemental (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a 3rd level small air elemental (20 hp).
+
+5th level spell: You now summon a 5th level air elemental (33 hp).
+
+7th level spell: You now summon a 7th level big air elemental (47 hp).
+
+9th level spell: You now summon a 9th level epic air elemental (85 hp).
+
+##### Summon Earth Elemental (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a 3rd level small earth elemental (17 hp).
+
+5th level spell: You now summon a 5th level earth elemental (26 hp).
+
+7th level spell: You now summon a 7th level big earth elemental (44 hp).
+
+9th level spell: You now summon a 9th level epic earth elemental (70 hp).
+
+##### Summon Fire Elemental (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a 3rd level small fire elemental (21 hp).
+
+5th level spell: You can now summon a 5th level fire elemental (33 hp).
+
+7th level spell: You can now summon a 7th level big fire elemental (48 hp).
+
+9th level spell: You can now summon a 9th level epic fire elemental (83 hp).
+
+##### Summon Water Elemental (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a 3rd level small water elemental (18 hp).
+
+5th level spell: You summon a 5th level water elemental (30 hp).
+
+7th level spell: You summon a 7th level big water elemental (45 hp).
+
+9th level spell: You summon a 9th level epic water elemental (80 hp).
+
+#### 5th Level Spells
+
+##### Flame Seeds (Fire)
+
+Ranged spell
+
+Daily
+
+**Targets:** 1d3 + 1 nearby enemies
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 3d12 + Wisdom fire damage, and 5 ongoing fire damage (hard save ends, 16+).
+
+**Effect:** Until the end of the battle, you can use a quick action once per turn to increase the _flame seeds_ ongoing fire damage by 5 for each target that hasn’t saved. (Yes, you can use a quick action the same turn that you cast the spell.)
+
+7th level spell: 5d12 damage.
+
+9th level spell: 8d12 damage.
+
+##### Fog Bank (Water)
+
+Ranged spell
+
+Daily
+
+**Targets:** Each creature in the battle, including you
+
+**Effect:** Until the start of your next turn, when a target attempts to attack, ready an action, or delay, it must roll a hard save (16+). If the target fails, it expends that action to no effect.
+
+9th level spell: You can now choose which creatures in the battle the spell targets.
+
+#### 7th Level Spells
+
+##### Lightning Strikes (Air)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby or faraway enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 10d8 + Wisdom lightning damage.
+
+**Miss:** 15 lightning damage.
+
+**Effect:** Until the end of the battle, when the escalation die is odd at the start of your turn, repeat this attack once that turn against one random nearby enemy as a free action, even if you don’t have line of sight to that creature.
+
+9th level spell: 10d12 damage; 25 miss damage.
+
+#### 9th Level Spells
+
+##### Wall of Stone (Earth)
+
+Ranged spell
+
+Daily
+
+**Effect:** You create a more or less impenetrable wall of stone that’s pretty big. You can’t drop it on top of enemies or bend it after creating it, but it can form natural flowing shapes like a river of stone that’s at most 40 feet high, 120 feet long, and 10 feet thick. If you’re straining to come up with nasty ways to use the wall, you’re breaking the spirit of the spell, since it’s just supposed to be a stone wall that blocks most other creatures’ movements.
+
+You, the spellcasting druid, can move through the wall at will, but you can’t end your turn inside it.
+
+The wall isn’t permanent: walls of stone generally disappear at sunrise or sunset.
+
+#### Summoning Rules
+
+These general rules also apply to the necromancer’s Summoning class feature.
+
+##### Standard action spells
+
+Casting a summoning spell generally requires a standard action. The creature(s) you summon appears next to you, though feats or powers might enable you to summon it nearby instead.
+
+##### Duration
+
+A summoned creature fights for you until the end of the battle or until it drops to 0 hit points. At 0 hp, summoned creatures are slain and removed from the battle.
+
+##### One summoning spell at a time
+
+Each spellcaster can have only a single summoning spell active at a time. If all the creatures from an earlier summoning spell have been slain, you’re free to cast another. Alternatively, you can dismiss your own previously summoned creatures as a quick action to clear the way for a new summoning spell.
+
+##### Halfway there
+
+Summoned creatures are not the same as real creatures. They’re partly real, partly magical. Their abilities don’t always match the capabilities of the creatures that the adventurers encounter _for real_. Sometimes this is reflected in a summoned creature’s attacks or abilities. It’s always reflected in a summoned creature’s hit points.
+
+##### Hit points
+
+Each summoned creature stat block indicates its base hit points. Starting hit points for summoned creatures are nearly always lower than hit points for non-summoned versions of the same creature. Some class feats might increase the hit points of summoned creatures.
+
+##### Actions on arrival
+
+The turn you summon a creature, that creature takes its turn immediately after your turn in initiative order. During its turn, the summoned creature can act like any other creature, taking a standard, move, and quick action. The summoned creature continues to take its turn immediately after you (even if your initiative order changes) until the end of the battle.
+
+##### Escalation die
+
+As a rule, summoned creatures don’t benefit from the escalation die. A summoned creature can add the escalation die to attacks, however, if _you use a quick action_ to give it orders or magical reinforcement. The summoned creature then gets to use the escalation die until the start of your next turn, including for opportunity attacks and other attacks that it gets to make during other creatures’ turns.
+
+For example, during the turn you summon the creature, you use a quick action afterward to give it orders, allowing it to use the escalation die bonus. At the start of your next turn, the creature no longer gets to use the escalation die, so you’ll have to use another quick action again during that turn for the creature to keep getting the benefit.
+
+If you’ve summoned a mob of mooks, a single quick action lets every member of the mob use the escalation die.
+
+##### Allies
+
+Summoned creatures generally count as your allies (for roleplaying as well as for resolving effects).
+
+##### No recoveries, bad healing
+
+Summoned creatures don’t have recoveries. If you cast a healing spell on a summoned creature that requires the use of a recovery, the summoned creature heals hit points equal to your level. If you use an effect that would heal a summoned creature without using a recovery, the summoned creature only heals half the normal hit points of the effect. Temporary hit points still work normally.
+
+##### No nastier specials
+
+Creatures you summon don’t use nastier specials.
+
+##### Spell or creature
+
+When a summoning spell is cast, it’s definitely a spell. After casting the spell, a summoned creature is a creature.
+
+### Shifter
+
+You glory in shifting into the forms of animals that nature blessed with keen eyes, swift wings, and terrible fangs. You also gain a number of aspects that you can assume while battling in beast form to improve your capabilities.
+
+#### Shifter Initiate Level Progression
+| Druid Level        | Daily Scout Form Shifts | Daily Beast Form Shifts | Daily Beast Form Aspects |
+|--------------------|-------------------------|-------------------------|--------------------------|
+| Level 1 Multiclass | 1                       | —                       | —                        |
+| Level 1            | 1                       | 1                       | —                        |
+| Level 2            | 1                       | 1                       | —                        |
+| Level 3            | 1                       | 1                       | 1                        |
+| Level 4            | 1                       | 1                       | 1                        |
+| Level 5            | 1                       | 1                       | 1                        |
+| Level 6            | 1                       | 2                       | 1                        |
+| Level 7            | 1                       | 2                       | 1                        |
+| Level 8            | 2                       | 2                       | 2                        |
+| Level 9            | 2                       | 2                       | 2                        |
+| Level 10           | 2                       | 2                       | 2                        |
+
+#### Shifter Adept Level Progression
+| Druid Level        | Daily Scout Form Shifts | Daily Beast Form Shifts | Daily Beast Form Aspects |
+|--------------------|-------------------------|-------------------------|--------------------------|
+| Level 1 Multiclass | 1                       | At-will                 | —                        |
+| Level 1            | 1                       | At-will                 | 1                        |
+| Level 2            | 1                       | At-will                 | 2                        |
+| Level 3            | 1                       | At-will                 | 3                        |
+| Level 4            | 1                       | At-will                 | 3                        |
+| Level 5            | 2                       | At-will                 | 4                        |
+| Level 6            | 2                       | At-will                 | 4                        |
+| Level 7            | 2                       | At-will                 | 4                        |
+| Level 8            | 3                       | At-will                 | 5                        |
+| Level 9            | 3                       | At-will                 | 5                        |
+| Level 10           | 3                       | At-will                 | 5                        |
+
+#### Scout Form
+
+Scout forms are magical versions of normal, smaller animals that are useful for scouting, such as bobcats, coyotes, owls, lizards, dire rats, giant spiders, and so on. In scout form, you shouldn’t have any problem slipping through the world without being troubled by any but the most serious defenses. However, you don’t look like a natural animal; there’s something extremely magical about you.
+
+Becoming a small animal isn’t a perfect translation of self. Your humanoid brain doesn’t work the same when you’ve shifted into scout form. You don’t talk. You can’t cast spells. Your magical items and possessions change shape with you, but you don’t get to use them in scout form. You maintain your identity and know who your allies are, but you’re as much an animal as a person while in the form.
+
+##### Fighting in Scout Form
+
+Fighting in scout form should be avoided unless you’re fighting a mundane animal. If you do attempt to fight, your attacker hits you unless he rolls a natural 1, and taking damage this way transforms you back into humanoid form.
+
+##### Shifting Into Scout Form and Back
+
+Transforming from humanoid or beast form into scout form requires a standard action. To transform back to human form from scout form requires a quick action. A Shifter adept can transform directly from scout to beast form (as a quick action), but a Shifter initiate must transform to human form first. You can only shift once per round. You can stay in scout form as long as you like, or switch back to humanoid form and then back again the next round.
+
+##### Using Scout Form Shifts
+
+Shifting into scout form is a daily, but you can do it at will. You can shift for roleplaying reasons, or for combat reconnaissance. To gain an advantage for an upcoming battle (or one just about to start), using your scout form requires a skill check.
+
+Before rolling initiative, you expend one daily scout form use and roll a skill check to see how successful you were with your combat recon. Depending on the terrain, the weather, and the particular enemies or dangers, the GM will ask you to use an ability score that makes sense for the situation just like any other check, though Wisdom, Dexterity, and Strength are often common choices.
+
+You’ll normally roll against the standard difficulty of the current environment. While in scout form in an adventurer-tier area, the normal check starts at DC 15, a hard check is DC 20, and a ridiculously hard check is DC 25. Champion tier increases the DC by 5, and epic tier by 5 more. Note that a successful check that qualifies for a higher DC gains you the information/advantage for that result, plus any lower results. A normal success or better probably negates any chance of an ambush or surprise by the enemy you’ve scouted.
+
+**Failure:** Nothing came of your scouting.
+
+**Normal success:** You gain a +4 bonus to initiative this battle.
+
+**Hard success:** As a free action at some point during the battle, you can grant one of your allies a reroll on an attack roll or save. That ally must take the new result. You must explain how something that happened while you were scouting contributed to this benefit.
+
+**Ridiculously hard success:** The GM chooses between giving _you_ a reroll at some point during the battle, or giving you a floating story-guide icon relationship result of 6 with a random icon.
+
+You only need to take one of the two adventurer-tier feats to access the champion-tier feat. You can also take both adventurer-tier feats, if you wish.
+
+_Adventurer Feat_
+
+Your temporary animal background roll is a 1d6 instead of 1d4 + 1, and count a 1 rolled as a 2.
+
+_Adventurer Feat_
+
+A normal success with your combat recon skill check also grants your allies a +2 bonus to initiative this battle.
+
+_Champion Feat_
+
+Rerolls from your combat recon exploits gain a +2 bonus.
+
+_Epic Feat_
+
+You now get two benefits instead of one when you succeed at a ridiculously hard skill check with your scout form.
+
+#### Beast Form
+
+Shifter initiates have a certain number of uses of beast form each day, allowing them to fight one or more battles in the shape of powerful predators. Since beast form transformations are like other daily powers, lasting no more than five minutes, Shifter initiates seldom stay in beast form, instead moving around in humanoid form or scout form.
+
+Shifter adepts can use beast form at-will.
+
+##### Beast Form
+
+Daily for Shifter initiates (1 or 2 uses)
+
+At-Will for Shifter adepts
+
+Quick action
+
+**Effect:** You leave your humanoid form behind and assume the form of a deadly predator such as a wolf, panther, tiger, bear, wolverine, lion, or another animal that you are naturally connected to.
+
+  
+  
+
+The choice of what type of animal you become is up to you. You don’t always have to change into the same thing—your choices can suit the story. Stick to four-legged natural predators, not creatures with supernatural abilities or the ability to fly.
+
+Shifter adepts can speak in growly voices and cast spells while in beast form. Shifter initiates can speak in beast form but can’t cast spells unless they take the champion-tier feat below.
+
+_**Magic items:**_ Your magic items stick with you and you get the benefit of their default bonuses. Yes, this means the bonuses from your magic axe translate to your beast form. Shifter adepts can use their magic item powers while in beast form. Shifter initiates can’t, but see the champion-tier feat below.
+
+_**Beast form actions:**_ Shifter adepts can shift freely between humanoid form and beast form during a battle. Shifter initiates who shift into beast form use up one of their daily beast form shifts, but they can shift between beast form and humanoid form without using a daily shift for the rest of that battle.
+
+For both adepts and initiates, shifting to humanoid form during your turn is a quick action. So is shifting back to beast form.
+
+_**Beast aspects:**_ While in beast form, you can take on aspects of different beasts to help you in battle (see below). You don’t have to use the aspects; they’re an option to improve your beast form attacks and powers, not a requirement.
+
+While in beast form, you attack in melee using a _beast form attack_.
+
+##### Beast Form Attack
+
+Melee attack
+
+At-Will
+
+**Attack:** Strength or Dexterity + Level vs. AC
+
+**Natural Even Hit:** 1d10 damage per level + Strength or Dexterity damage.
+
+**Natural Odd Hit:** 1d6 damage per level + Strength or Dexterity damage.
+
+**Miss:** Repeat the attack against the same or a different target. This second attack has no _miss_ effect.
+
+_Adventurer Feat_
+
+For both initiates and adepts, your second beast form attack (the one you roll when the first attack misses) now deals miss damage equal to your level. If you are a Shifter adept, you can have two beast aspects active at the same time. If you start using a third aspect, one of the two previous aspects of your choice ends.
+
+_Champion Feat_
+
+If you are a Shifter initiate, you can now cast spells and use magic item powers while in beast form. If you are a Shifter adept, you can have three beast aspects active at the same time. If you start using a fourth aspect, one of the two previous aspects of your choice ends.
+
+_Epic Feat_
+
+If you are a Shifter adept, your beast form can now be a lycanthropic form when you wish—furred, deadly, and possessing a new power that you can use only while in lycanthropic form: _shake it off_.
+
+_Shake It Off_
+
+**Special:** You gain access to this power by taking the epic feat for _beast form attack_. To use it, you must be using at least one beast aspect.
+
+**Recharge** 16+ after battle
+
+Free action
+
+**Trigger:** You take damage while fighting in beast form
+
+**Effect:** You end a beast aspect power that you are using and then take only 6d6 damage from the triggering attack and ignore the rest of the damage. You still suffer any other effects of the attack (including ongoing damage).
+
+##### Beast Aspect
+
+Beast aspects are powers you can use while in beast form to help you in battle. You must choose the aspects you know at each full heal-up. You can select any of the following aspects beginning at 1st level.
+
+Normally you can use only one beast aspect at a time and using another aspect ends the previous one. The _beast form attack_ feats change that for the Shifter adept.
+
+_**Beast aspect bonuses**_**:** Many beast aspects provide bonuses to defenses or attacks. Shifter adepts can combine bonuses to the same stats from two aspects they are using simultaneously, an exception to the general rule that bonuses don’t stack. For example, a Shifter adept using _bear aspect_ with its champion feat would have a +2 AC, and if the adept was also using _behemoth aspect_ with its champion feat, the total defensive bonuses for the adept would be +5 AC and +3 PD.
+
+_**Effects:**_ Beast aspects only affect you while you are in beast form, which means that every aspect should be understood to read “while in beast form” for all its effects and powers.
+
+Shifting out of beast form to humanoid form prevents a beast aspect from having any effect, but it doesn’t end the aspect. When you shift back to beast form, the aspect is in effect again. Aspects last until the end of the battle.
+
+_**Appearances:**_ The names of the aspects are a guide to what you might look like when channeling that beast, but it’s also possible to decide that your usual beast form is, for example, wolf-like, and that using bear aspect or behemoth aspect merely adds bear-like or behemoth-like qualities to your standard wolf-shape.
+
+_Bear Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, while in beast form you gain a +2 bonus to attacks and damage against lower level enemies and mooks of any level (damage bonus increases to 2 + double your Strength or Dexterity modifier at 5th level; damage bonus increases to 2 + triple your Strength or Dexterity modifier at 8th level).
+
+**Adept Effect:** As the initiate effect, and when you first shift into this aspect, roll your recovery dice as if you were healing, but you instead gain that many temporary hit points. You don’t spend a recovery.
+
+Adventurer Feat
+
+The initiate effect’s attack bonus is now +4 instead of +2.
+
+Champion Feat
+
+Adepts also gain a +2 AC bonus while using this aspect.
+
+Epic Feat
+
+Until the first time it recharges each day, _bear aspect_ is recharge 11+ instead of recharge 16+ for adepts.
+
+_Behemoth Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** You gain a +2 bonus to AC and PD.
+
+**Adept Effect:** As the initiate effect, and the first time you become staggered this battle, roll a hard save (16+). If you fail, choose one of the two following benefits. If you succeed, you get both.
+
+_Endurance:_ You can heal using a recovery.
+
+_Wrath:_ Begin rolling 2d20 for each of your melee attacks and choose the result you prefer until the end of the battle or until you make both rolls for a melee attack and each roll is a natural 10 or less.
+
+Adventurer Feat
+
+The recovery from the adept’s _endurance_ effect is now free.
+
+Champion Feat
+
+For adepts, the bonus to AC and PD is now +3 instead of +2.
+
+Epic Feat
+
+The save that determines the adept’s benefit(s) is now a normal save.
+
+_Mantis Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, when an enemy engaged with you fails a disengage check, you can make an opportunity attack against it. In addition, your natural even beast form attack rolls that would normally deal damage equal to your level deal half damage instead.
+
+**Adept Effect:** As the initiate effect, and you gain a +1d3 bonus to AC and a +1d3 bonus to PD (two separate rolls). Insects are unpredictable.
+
+Adventurer Feat
+
+When an enemy attempts to disengage from you while you are using this aspect, it takes a penalty to the check equal to your Strength or Dexterity modifier.
+
+Champion Feat
+
+Adept effect bonuses are now d4s instead of d3s.
+
+Epic Feat
+
+Until the first time it recharges each day, _mantis aspect_ is recharge 11+ instead of recharge 16+ for adepts.
+
+_Leopard Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, when an enemy misses you with a melee attack and rolls a natural 1–4, you gain an additional standard action during your next turn. You can only gain one additional standard action a turn this way. Powers like _elven grace_ or a command won’t stack with this effect either.
+
+**Adept Effect:** As the initiate effect, and you gain a +2 bonus to AC. You also gain a +5 bonus to disengage checks and to saves against being stuck, dazed, or stunned.
+
+_Owlbear Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, your crit range with melee attacks expands by 2.
+
+**Adept Effect:** As the initiate effect, and you gain a +1 bonus to melee attacks and a +2 bonus to AC and PD.
+
+Adventurer Feat
+
+When you score a critical hit, you heal hit points equal to your level + your Wisdom modifier (double your Wisdom modifier at 5th level; triple it at 8th level).
+
+Champion Feat
+
+While you are in this aspect, your critical hits with melee attacks deal triple damage instead of double damage.
+
+Epic Feat
+
+Until the first time it recharges each day, _owlbear aspect_ is recharge 11+ instead of recharge 16+ for adepts.
+
+_Tiger Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, you gain the benefits of two-weapon fighting: if your attack roll is a natural 2, you can reroll the attack, but must use the reroll. In addition, the crit range of attacks you reroll this way expands by 4.
+
+**Adept Effect:** As the initiate effect, and increase the size of your beast form melee attack damage dice by one size (for example, d6s become d8s, and d10s become 12s).
+
+Adventurer Feat
+
+You also gain a +2 attack bonus with any attack you reroll while using this aspect.
+
+Champion Feat
+
+When you move and then attack an enemy you were not engaged with at the start of your turn, you can reroll your first natural odd attack roll each turn, but must use the reroll. (The initiate effect bonuses don’t apply to this reroll.)
+
+Epic Feat
+
+Until the first time it recharges each day, _tiger aspect_ is recharge 11+ instead of recharge 16+ for adepts.
+
+_Wolverine Aspect_
+
+Beast aspect
+
+Daily, or recharge 16+ for adepts
+
+Quick action
+
+**Initiate Effect:** Until the end of the battle, when your melee attacks hit an enemy that has more hit points than you, the target takes 1d6 extra damage from the hit.
+
+**Adept Effect:** As the initiate effect, and you gain a +2 bonus to all defenses. You can also rally once this battle as a quick action instead of a standard action.
+
+Adventurer Feat
+
+Your extra melee damage while using this aspect increases according to your level:
+
+2nd level druid: +1d8 damage.
+
+4th level druid: +1d10 damage.
+
+6th level druid: +2d6 damage.
+
+8th level druid: +3d6 damage.
+
+10th level druid: +3d12 damage.
+
+Champion Feat
+
+You can use the damage bonus against an enemy that started the battle with more hit points than you, but no longer does.
+
+Epic Feat
+
+Until the first time it recharges each day, _wolverine aspect_ is recharge 11+ instead of recharge 16+ for adepts.
+
+### Terrain Caster
+
+There are eight different ranges of terrain that are relevant to druidic magic:
+
+1.  cave, dungeon, underworld
+    
+2.  forest, woods
+    
+3.  ice, snowfields, tundra
+    
+4.  migration route (large herd animal)
+    
+5.  mountains
+    
+6.  plains, overworld
+    
+7.  ruins
+    
+8.  swamp, lake, river
+    
+
+At-will or once-per-battle spells provided by terrain caster adventurer feats can be cast in any terrain you like. Daily spells must match the type of terrain you’re in, though you don’t have to memorize them like a wizard, and the spell level you cast them at is your current character level.
+
+Terrains need not be exclusive; ruins can exist on mountains, and the terrain caster can draw upon each. Any ambiguity should be decided by the GM.
+
+#### Terrain Caster Initiate Level Progression
+| Druid Level        | Daily Spells  | Level the Spells are Cast At |
+|--------------------|---------------|------------------------------|
+| Level 1 Multiclass | 1             | 1st level                    |
+| Level 1            | 1             | 1st level                    |
+| Level 2            | 1             | 1st level                    |
+| Level 3            | 2             | 3rd level                    |
+| Level 4            | 2             | 3rd level                    |
+| Level 5            | 2             | 5th level                    |
+| Level 6            | 3             | 5th level                    |
+| Level 7            | 3             | 7th level                    |
+| Level 8            | 3             | 7th level                    |
+| Level 9            | 3             | 9th level                    |
+| Level 10           | 3             | 9th level                    |
+
+#### Terrain Caster Adept Level Progression
+| Druid Level        | Daily Spells  | Level the Spells are Cast At |
+|--------------------|---------------|------------------------------|
+| Level 1 Multiclass | 1             | 1st level                    |
+| Level 1            | 1             | 1st level                    |
+| Level 2            | 2             | 1st level                    |
+| Level 3            | 3             | 3rd level                    |
+| Level 4            | 4             | 3rd level                    |
+| Level 5            | 5             | 5th level                    |
+| Level 6            | 5             | 5th level                    |
+| Level 7            | 6             | 7th level                    |
+| Level 8            | 6             | 7th level                    |
+| Level 9            | 7             | 9th level                    |
+| Level 10           | 7             | 9th level                    |
+
+#### Cave, Dungeon, Underworld
+
+##### Adventurer Feat
+
+You gain the _ways of the dark_ spell below.
+
+##### Champion Feat
+
+Once per battle, when an attack targeting MD hits you while you’re not fighting in bright sunlight, you can force the attacker to reroll that attack, but you must accept the reroll.
+
+##### Epic Feat
+
+You can now cast one bonus daily cave/dungeon/underworld spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Ways of the Dark (Terrain Feat Spell)
+
+At-Will (in any terrain)
+
+Ranged spell
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 1d8 psychic damage (don’t add your ability score modifier).
+
+**Natural Even Hit:** As a hit, plus the target can’t attack the druid until the end of its next turn unless the druid moves to engage the target.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 2d8 damage.
+
+5th level spell: 3d8 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d8 damage.
+
+##### Spider Climb (1st level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You
+
+**Effect:** Until the end of the battle or for five minutes, you can climb up sheer surfaces and stick to ceilings as if you were a spider. You can fight and cast spells normally while climbing.
+
+3rd level spell: If you’re fighting while standing upside down on a ceiling or sideways on a wall, you can reroll the first natural odd attack roll you get if you tell a fun story about how the _spider climb_ effect is letting you fight better than you ordinarily would!
+
+5th level spell: While the spell is in effect, you can fall up to 100 feet without taking damage.
+
+7th level spell: The effect lasts up to an hour and you can also target a nearby ally.
+
+9th level spell: The spell now targets you and 1d4 + 1 nearby allies.
+
+##### Fungal Ambuscade (3rd level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** The target takes 15 ongoing poison damage (two saves ends).
+
+**Miss:** The target takes 5 ongoing poison damage (two saves ends).
+
+5th level spell: 25 ongoing damage on a hit, 10 ongoing damage on a miss.
+
+7th level spell: 50 ongoing damage on a hit, 20 ongoing damage on a miss.
+
+9th level spell: 90 ongoing damage on a hit, 40 ongoing damage on a miss.
+
+##### Spikestones (5th level)
+
+Ranged spell
+
+Daily
+
+**Effect:** Until the end of the battle, the area the battle is occurring in is dangerous to move in. When an enemy moves through the area on the ground (enemies using _teleport_ or similar powers aren’t affected), it must roll a normal save that turn. On a failure, that creature takes 7d6 damage. If they move again that turn, they don’t have to roll a save.
+
+You can move normally in the area. Your allies must roll an easy save (6+); if they fail they take half damage when they move.
+
+Since the spell normally only works underground, it affects creatures with _flight_ because it’s assumed that nasty stalactites jut out from the ceiling as well as the walls and floors. If you’re in a _giant_ cavern when you cast it, fliers could probably zip around away from surfaces without too much trouble (GM’s call).
+
+7th level spell: 7d10 damage.
+
+9th level spell: 9d10 damage.
+
+#### Forest, Woods
+
+##### Adventurer Feat
+
+You gain the _rain of acorns_ spell below.
+
+##### Champion Feat
+
+Once per battle when you hit an enemy that’s a beast with _rain of acorns_, the target is also confused until the end of your next turn.
+
+##### Epic Feat
+
+You can now cast one bonus daily forest/woods spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Rain of Acorns (Terrain Feat Spell)
+
+Ranged spell
+
+At-Will (in any terrain)
+
+**Targets:** 1d3 nearby enemies in a group
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d4 damage + Wisdom damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 2d4 damage.
+
+5th level spell: 2d6 damage.
+
+7th level spell: 4d6 damage.
+
+9th level spell: 6d6 damage.
+
+_Champion Feat_
+
+This spell now targets 1d4 enemies in a group.
+
+##### Barkskin (1st level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You or one nearby ally wearing light armor or no armor
+
+**Effect:** Until the end of the battle, the target gains a +3 bonus to AC except against attacks that deal fire damage.
+
+5th level spell: The +3 bonus also applies to PD except against attacks that deal fire damage.
+
+9th level spell: You can now choose two targets.
+
+##### Entangle (3rd level)
+
+Ranged spell
+
+Daily
+
+**Target:** 1d3 nearby creatures
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 5d6 + Wisdom damage, and if the target has 80 hp or fewer after the damage, it’s stuck (save ends).
+
+**Miss:** Damage equal to your level, if the target has 80 hp or fewer after the damage, it’s stuck (easy save ends, 6+).
+
+5th level spell: 5d10 damage; hit/miss effect affects targets with 135 hp or fewer.
+
+7th level spell: 6d10 damage; hit/miss effect affects targets with 220 hp or fewer.
+
+9th level spell: 10d10 damage; hit/miss effect affects targets with 350 hp or fewer.
+
+##### Plantwalk (5th level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You
+
+**Effect:** Until the end of the turn, you can teleport once as a move action by moving into a tree or other large plant and emerging from another plant or tree of the same species you can see or out of your line of sight. If you go beyond your line of sight, the GM chooses how far you can go, up to a mile.
+
+Once per level when you cast this spell, you also summon a 5th level earth elemental beside one of the trees or plants involved in your teleport. Use the elemental caster’s _summon earth elemental_ spell.
+
+7th level spell: The once per level summoning now summons a 7th level earth elemental.
+
+9th level spell: You can now use the spell to teleport virtually unlimited distances as long as you travel to a grove or forest and emerge from a tree or plant well-known to you. The once per level summoning now summons a 9th level earth elemental.
+
+#### Ice, Tundra, Deep Snow
+
+##### Adventurer Feat
+
+You gain the _frost touch_ spell below.
+
+##### Champion Feat
+
+You gain _resist cold 16+_ and your spells ignore the _resist cold_ abilities that the targets of your spells have.
+
+##### Epic Feat
+
+You can now cast one bonus daily ice/tundra/deep snow spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Frost Touch (Terrain Feat Spell)
+
+Close-quarters spell
+
+Once per battle (in any terrain)
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 2d6 + Wisdom cold damage, or 3d6 + Wisdom cold damage to an enemy you are engaged with.
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** Damage equal to your level.
+
+3rd level spell: 4d6 damage, or 6d6 to an enemy you are engaged with.
+
+5th level spell: 5d10 damage, or 6d10 to an enemy you are engaged with.
+
+7th level spell: 8d10 damage, or 10d10 to an enemy you are engaged with.
+
+9th level spell: 2d6 x 10 damage, or 2d8 x 10 to an enemy you are engaged with.
+
+##### Ice Shield (1st level)
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You
+
+**Effect:** Until the end of the battle, when an enemy engaged with you attacks you and rolls a natural 1–15, it takes 1d10 cold damage after the attack.
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 10d10 damage.
+
+##### Icicle (3rd level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby or faraway creature
+
+**Attack:** Wisdom + Level vs. PD
+
+**Natural Even Hit:** 5d10 + Wisdom cold damage, and the target is hampered (easy save ends, 6+).
+
+**Natural Odd Hit:** 5d10 + Wisdom cold damage, and the target is stuck (easy save ends, 6+).
+
+**Miss:** Half damage, and the target is stuck until the end of its next turn.
+
+5th level spell: 7d10 damage.
+
+7th level spell: 10d12 damage.
+
+9th level spell: 2d10 x 10 damage.
+
+##### Cone of Cold (5th level)
+
+Ranged spell
+
+Daily
+
+**Targets:** 1d4 nearby enemies in a group
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 10d6 + Wisdom cold damage.
+
+**Natural Even Hit:** As a hit, plus the target is stuck (save ends).
+
+**Miss:** Half damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+#### Migration Route (Large Herd Animal)
+
+##### Adventurer Feat
+
+You gain the _whoomph_ spell below.
+
+##### Champion Feat
+
+When you cast _whoomph_ during a battle, you can cast _the beast shrugs_ later in that battle even if you are not on migration route terrain.
+
+##### Epic Feat
+
+You can now cast one bonus daily migration route spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Whoomph (Terrain Feat Spell)
+
+Close-quarters spell
+
+At-Will (in any terrain)
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d8 + Wisdom damage; or 2d8 + Wisdom damage against a mook.
+
+**Miss:** Damage equal to your level against a non-mook; no effect against a mook.
+
+3rd level spell: 3d6 damage, or 6d6 against a mook.
+
+5th level spell: 5d6 damage, or 6d10 against a mook.
+
+7th level spell: 5d8 damage, or 10d8 against a mook.
+
+9th level spell: 8d10 damage, or 3d6 x 10 against a mook.
+
+##### The Beast Shrugs (3rd level)
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle, the target can use a quick action (once per turn) to heal 4d6 hit points. The target can take this action only when it’s not staggered.
+
+5th level spell: Heal 6d6 hit points.
+
+7th level spell: Heal 7d10 hit points.
+
+9th level spell: Heal 10d10 hit points.
+
+##### Stomp! (5th level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby large, huge, or even bigger enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 7d12 + Wisdom damage.
+
+**Miss:** You don’t expend the spell, but must cast it again with your next standard action. If you don’t, you take damage from the spell as if you had been hit and the spell is expended.
+
+7th level spell: 3d4 x 10 damage.
+
+9th level spell: 3d8 x 10 damage.
+
+##### Migratory Teleport (7th level)
+
+Ranged spell
+
+Daily
+
+**Effect:** You and up to 4 allies next to you can teleport to the site of any migratory beast herd in the world.
+
+When you teleport, roll a d20. If you roll a 1, something unusual intervened and you arrive at a different herd site than you had intended (GM’s choice). Otherwise, you and your allies arrive somewhere hear the desired herd. Unlike the wizard’s 9th level _teleport_ spell, this spell doesn’t allow you to choose your precise destination.
+
+Any effects of spells or items cast/created before teleporting are canceled and no longer function on arrival, so it’s best to wait and use such spells after you arrive.
+
+9th level spell: You can now try to teleport to any location along the migration route. Stabbing your finger on the world map suffices, but your aim won’t be perfect. Attempts to teleport to places off the map to the north or west usually don’t work.
+
+#### Mountains
+
+##### Adventurer Feat
+
+You gain the _spark_ spell below.
+
+##### Champion Feat
+
+Once per day, you can heal using a second recovery when some other effect has enabled you to heal using a single recovery. This bonus recovery is a free recovery, but it doesn’t benefit from any bonuses the first recovery gains.
+
+##### Epic Feat
+
+You can now cast one bonus daily mountains spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Spark (Terrain Feat Spell)
+
+Close-quarters spell
+
+At-Will (in any terrain)
+
+**Target:** One nearby or faraway enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d8 + Wisdom lightning damage, or 2d8 + Wisdom lightning damage against a creature that is flying.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d6 damage, or 6d6 against a flying creature.
+
+5th level spell: 5d6 damage, or 6d10 against a flying creature.
+
+7th level spell: 5d8 damage, or 10d8 against a flying creature.
+
+9th level spell: 8d10 damage, or 3d6 x 10 against a flying creature.
+
+##### Rumble (1st level)
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** Until the end of the battle, when you end your turn engaged with one or more enemies, each of those creatures takes thunder damage equal to your Wisdom modifier.
+
+3rd level spell: 1d6 + Wisdom modifier damage.
+
+5th level spell: 2d6 + Wisdom modifier damage.
+
+7th level spell: 3d6 + Wisdom modifier damage.
+
+9th level spell: 4d6 + Wisdom modifier damage.
+
+##### Stoneskin (3rd level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You or one nearby ally
+
+**Effect:** The target gains _resist damage 16+_ against attacks targeting AC until the end of the battle or until two natural 16+ attack rolls against AC hit the target.
+
+5th level spell: _Resist damage_ now also applies to attacks targeting PD.
+
+9th level spell: _Resist damage_ increases to 18+.
+
+##### Call Lightning (7th level)
+
+Ranged spell
+
+Daily
+
+**Targets:** This spell generates a number of attacks equal to the escalation die. Each attack targets a random enemy. Determine the target of each attack just before rolling the attack, so that an enemy that drops to 0 hp won’t be targeted again.
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 5d12 + Wisdom lightning damage.
+
+**Miss:** Damage equal to your level.
+
+9th level spell: 7d12 damage.
+
+#### Plains, Overworld
+
+##### Adventurer Feat
+
+You gain the _sunbeams_ spell below.
+
+##### Champion Feat
+
+Once per battle as a free action, you can choose a spell that targets nearby creatures or enemies. That spell can target faraway creatures or enemies this battle.
+
+##### Epic Feat
+
+You can now cast one bonus daily plains/overworld spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Sunbeams (Terrain Feat Spell)
+
+Ranged spell
+
+At-Will (in any terrain)
+
+**Targets:** Up to two nearby or faraway enemies
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 1d4 + Wisdom fire damage.
+
+3rd level spell: 3d4 damage.
+
+5th level spell: 2d8 damage.
+
+7th level spell: 4d6 damage.
+
+9th level spell: 4d12 damage.
+
+##### Heat Metal (1st level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy in heavy armor, wearing metal armor, or using metal weapons
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 3d6 + Wisdom fire damage, and 10 ongoing fire damage and dazed (save ends both).
+
+**Miss:** 10 ongoing fire damage.
+
+3rd level spell: 5d6 damage, and 15 ongoing damage (hit and miss).
+
+5th level spell: 5d10 damage, and 25 ongoing damage (hit and miss).
+
+7th level spell: 9d10 damage, and 40 ongoing damage (hit and miss).
+
+9th level spell: 10d12 damage, and 50 ongoing damage (hit and miss).
+
+##### Air & Fire (3rd level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** During your next turn, you can cast a 3rd level daily Air or Fire spell from the Elemental Caster’s spell list even if you don’t ordinarily know that spell. The only limitation is that the spell can’t be a _summon elemental_ spell. Casting that spell neither counts against your daily Elemental Caster spell limit if you have that talent, nor does it count against your daily Terrain Caster spell limit.
+
+If something prevents you from casting the spell during your next turn, you still expend this daily spell.
+
+5th level spell: Now you can cast a 5th level daily Air or Fire spell.
+
+7th level spell: Now you can cast a 7th level daily Air or Fire spell.
+
+9th level spell: Now you can cast a 9th level daily Air or Fire spell.
+
+##### Harmony (5th level)
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Targets:** Two willing nearby allies (possibly including you).
+
+**Effect:** Until the end of the battle, when one of the targets takes damage, the target with the most hit points takes that damage instead (your choice on ties).
+
+The effect doesn’t work while a target is at 0 hit points or below. Temporary hit points also don’t count.
+
+7th level spell: The spell can now target up to three willing allies.
+
+9th level spell: The spell can now target up to four willing allies.
+
+#### Ruins
+
+##### Adventurer Feat
+
+You gain the _ruination_ spell below.
+
+##### Champion Feat
+
+Once per day when you drop to 0 hit points or below, you can roll a normal save. If you succeed, heal using a recovery before going unconscious. If you fail, it counts as a failed death check.
+
+##### Epic Feat
+
+You can now cast one bonus daily ruins spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Ruination (Terrain Feat Spell)
+
+Ranged spell
+
+Once per battle (in any terrain)
+
+**Target:** The nearby enemy with the highest MD (you don’t have to be able to see the enemy)
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** Each nearby enemy takes 2d6 damage (don’t add your ability score modifier). For mooks, deal the damage once to the mob, not to each member of it.
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 9d6 damage.
+
+9th level spell: 6d12 damage.
+
+##### Inevitable Collapse (1st level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 2d6 + Wisdom damage, and 10 special ongoing damage.
+
+_special ongoing damage:_ The target can’t start rolling saves against this damage until you or your allies attack it, or until it starts its turn staggered.
+
+**Miss:** 5 special ongoing damage (as above).
+
+3rd level spell: 5d6 damage, and 15 ongoing damage; 5 ongoing on a miss.
+
+5th level spell: 5d10 damage, and 20 ongoing damage; 10 ongoing on a miss.
+
+7th level spell: 8d10 damage, and 25 ongoing damage; 15 ongoing on a miss.
+
+9th level spell: 10d12 damage, and 40 ongoing damage; 20 ongoing on a miss.
+
+##### How Things End (5th level)
+
+Ranged spell
+
+Daily
+
+**Targets:** Up to 3 nearby staggered enemies
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 6d10 + Wisdom psychic damage.
+
+**Natural Even Hit:** As a hit, plus the target can’t attack you during its next turn.
+
+**Miss:** Half damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+##### Devastation (9th level)
+
+Ranged spell
+
+Daily
+
+**Special:** You can cast this spell only once per level.
+
+**Target:** One structure constructed by mortals that isn’t in the overworld, in the underworld, or under an icon’s personal magical protection.
+
+**Skill Check:** To gain the effect, you must succeed on a skill check corresponding to the tier of the structure and the GM’s assessment of the difficulty: normal, hard, or ridiculously hard.
+
+**Effect:** The structure begins to come down as if it aged centuries in minutes. It may take up to an hour to collapse entirely. Supremely magical structures may have their own ways of regenerating.
+
+#### Swamp, Lake, River
+
+##### Adventurer Feat
+
+You gain the _poison thorns_ spell below.
+
+##### Champion Feat
+
+You gain _resist poison 16+._
+
+##### Epic Feat
+
+You can now cast one bonus daily swamp/lake/river spell that doesn’t count against your total daily spells, but you still can’t cast a specific daily spell of that type more than once per day.
+
+##### Poison Thorns (Terrain Feat Spell)
+
+Ranged spell
+
+At-Will (in any terrain)
+
+**Target:** One random nearby enemy (you don’t have to be able to see that enemy)
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** 5 damage, and 5 ongoing poison damage.
+
+3rd level spell: 8 damage, and 8 ongoing poison damage.
+
+5th level spell: 13 damage, and 13 ongoing poison damage.
+
+7th level spell: 20 damage, and 20 ongoing poison damage.
+
+9th level spell: 30 damage, and 30 ongoing poison damage.
+
+##### The Big Muddy (1st level)
+
+Ranged spell
+
+Daily
+
+**Targets:** Each nearby enemy with 50 hit points or fewer that is touching the ground or the water and doesn’t have the _flight_ ability
+
+**Attack:** Wisdom + Level vs. PD
+
+**Hit:** The target is stuck (save ends).
+
+3rd level spell: Targets with 80 hit points or fewer.
+
+5th level spell: Targets with 140 hit points or fewer.
+
+7th level spell: Targets with 200 hit points or fewer.
+
+9th level spell: Targets with 320 hit points or fewer.
+
+##### Reclamation (3rd level)
+
+Ranged spell
+
+Daily
+
+**Targets:** Up to two nearby non-mook enemies with the fewest hit points (you don’t have to be able to see those enemies)
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 5d6 + Wisdom damage, and the target can’t heal (hard save ends, 16+).
+
+**Miss:** Half damage.
+
+5th level spell: 6d8 damage.
+
+7th level spell: 10d8 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+##### Purification Chant (7th level)
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Wisdom + Level vs. MD
+
+**Hit:** 2d6 x 10 + Wisdom psychic damage, and you and each of your nearby allies can roll a save with a +5 bonus against any save ends effect created by the target.
+
+**Miss:** Half damage, and you and 1d3 of your nearby allies can each roll a save against any save ends effect created by the target.
+
+9th level spell: 2d10 x 10 damage.
+
+### Warrior Druid
+
+Choose this talent if you want to fight well in melee with your normal weapons and armor.
+
+Spending a single talent on Warrior Druid lets you choose _one_ of the three following benefits:
+
+-   Your AC in light armor is 12 instead of 10 like most other druids.
+    
+-   You don’t take opportunity attacks from enemies engaged with you when you cast ranged druid spells.
+    
+-   Your base hit points are 7 + CON mod instead of 6 + CON mod.
+    
+
+If you use two talents to become a Warrior Druid adept, choose _three_ of the following benefits:
+
+-   Your AC in light armor is 12 instead of 10 like most other druids.
+    
+-   You don’t take opportunity attacks from enemies engaged with you when you cast ranged druid spells.
+    
+-   Your base hit points are 7 + CON mod instead of 6 + CON mod.
+    
+-   You can use one-handed 1d8 martial weapons without taking the –2 attack penalty that other druids suffer.
+    
+-   You can use a shield (in human form) without taking an attack penalty like other druids.
+    
+
+Like the fighter class, you gain access to flexible attacks when you make basic melee attacks during your turn. Roll your attack, then choose one of the flexible attacks you know that can be triggered by your natural attack roll. Unlike the fighter, you can usually use each of your flexible attacks only once per battle.
+
+If you’re also a Shifter initiate, you can use your Warrior Druid flexible attacks while in beast form, _but only_ with your first beast form attack roll each turn. Adepts can use them freely.
+
+#### Adventurer Feat
+
+Choose another Warrior Druid benefit you weren’t able to start with. Whether you’re an initiate or an adept, you can take this feat twice to gain the two Warrior Druid benefits you are missing.
+
+#### Warrior Druid Initiate Level Progression
+| Druid Level        | Druid Flexible Attacks |
+|--------------------|------------------------|
+| Level 1 Multiclass | 1                      |
+| Level 1            | 1                      |
+| Level 2            | 2                      |
+| Level 3            | 2                      |
+| Level 4            | 2                      |
+| Level 5            | 3                      |
+| Level 6            | 3                      |
+| Level 7            | 3                      |
+| Level 8            | 4                      |
+| Level 9            | 4                      |
+| Level 10           | 4                      |
+
+#### Warrior Druid Adept Level Progression
+| Druid Level        | Druid Flexible Attacks |
+|--------------------|------------------------|
+| Level 1 Multiclass | 1                      |
+| Level 1            | 2                      |
+| Level 2            | 3                      |
+| Level 3            | 4                      |
+| Level 4            | 4                      |
+| Level 5            | 4                      |
+| Level 6            | 5                      |
+| Level 7            | 5                      |
+| Level 8            | 6                      |
+| Level 9            | 6                      |
+| Level 10           | 6                      |
+
+#### Flexible Attacks
+
+Choose which flexible attacks you know. You can choose any of the following at 1st level, though some won’t work as well depending on your choice of talents.
+
+##### Ancestral Guidance
+
+Flexible once-per battle melee attack
+
+**Triggering Roll:** Natural odd roll
+
+**Effect:** Add damage to the attack equal to your Wisdom modifier, hit or miss. (Double your Wisdom modifier at 5th level; triple it at 8th level.)
+
+If you are a Warrior Druid adept and you use _ancestral guidance_ while in humanoid form, you also regain all the once-per-battle flexible attacks you have expended this battle.
+
+_Adventurer Feat_
+
+Once per battle when you make an attack against AC, you can instead make that attack against the target’s MD as the spirits guide your strike.
+
+_Champion Feat_
+
+When you use this flexible attack, you can roll a save against a save ends effect.
+
+##### Beast Spirits
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 19+, or Natural 18+ if you are a Shifter adept
+
+**Effect:** After the attack, as a free action you can cast one of the four spells listed below this attack: _behemoth’s endurance_, _bull’s strength_, _cat’s grace_, or _owl’s wisdom_. You choose which spell to cast. Using _beast spirits_ is normally the only way to access these spells.
+
+**Special:** The four _beast spirits_ spells last until the end of the battle or until the target falls unconscious. If the target already has a _beast spirits_ spell effect on it, that spell is cancelled when a new _beast spirits_ spell targets it.
+
+_Champion Feat_
+
+You can use the improved version of each spell as amended by the champion-tier feats listed underneath it.
+
+##### Behemoth’s Endurance
+
+Close-quarters spell
+
+Free action to cast when triggered
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle or until targeted with another _beast spirits_ spell, the target gains a +2 bonus to PD and temporary hit points equal to your level + your Wisdom modifier.
+
+_Champion Feat_
+
+The target instead gains a +4 bonus to PD and temporary hit points equal to your level + double your Wisdom modifier (triple your Wisdom modifier at 8th level).
+
+##### Bull’s Strength
+
+Close-quarters spell
+
+Free action to cast when triggered
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle or until targeted with another _beast spirits_ spell, the target gains a +1 bonus to melee attacks.
+
+_Champion Feat_
+
+The target gains a +2 bonus to melee attacks instead of +1.
+
+##### Cat’s Grace
+
+Close-quarters spell
+
+Free action to cast when triggered
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle or until targeted with another _beast spirits_ spell, the target gains a +1 bonus to AC.
+
+_Champion Feat_
+
+The target also gains a +2 bonus to disengage checks and Dexterity skill checks.
+
+##### Owl’s Wisdom
+
+Close-quarters spell
+
+Free action to cast when triggered
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle or until targeted with another _beast spirits_ spell, the target gains a +2 bonus to MD and a +1 bonus to saves.
+
+_Champion Feat_
+
+The target instead gains a +4 bonus to MD and a +2 bonus to saves.
+
+##### Elemental Pivot
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 18+
+
+**Effect:** During your next turn, you can cast an elemental caster’s Elemental Mastery at-will feat spell of your choice as a quick action, even if you don’t normally know that spell.
+
+_Adventurer Feat_
+
+If you also have the Elemental Caster talent, you gain a +2 attack bonus with that spell.
+
+_Champion Feat_
+
+Any other Elemental Caster spell you cast during your next turn also gains a +2 attack bonus.
+
+##### Greenmantle
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 18+
+
+**Effect:** You gain a +4 bonus to AC until an attack against AC misses you.
+
+_Adventurer Feat_
+
+If you are using a shield, _this_ flexible attack instead triggers on a natural 16+.
+
+_Champion Feat_
+
+The bonus now also applies to PD (and attacks against PD that miss).
+
+_Epic Feat_
+
+You now gain a +6 AC bonus instead of +4.
+
+##### Invoke the Storm
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 5, 10, 15, or 20
+
+**Effect:** Roll a d3. Deal lightning damage equal to five times the number you rolled to one nearby enemy other than the target of the triggering attack.
+
+_Adventurer Feat_
+
+Roll a d4 instead of a d3.
+
+_Champion Feat_
+
+Roll a d6 instead of a d4 and use whichever is higher, the escalation die or your d6 roll.
+
+_Epic Feat_
+
+Add the escalation die and your d6 roll together, then multiply by five for the damage you deal.
+
+##### Nature’s Fury
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 2–5
+
+**Effect:** The triggering attack deals half damage.
+
+_Adventurer Feat_
+
+Any allies engaged with the target can pop free from it if they wish.
+
+_Champion Feat_
+
+The flexible attack now also triggers on a natural odd miss.
+
+##### Red Claw
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural odd hit or miss
+
+**Effect:** Until the end of the battle, your animal companion gains a +1 attack bonus. If you use this flexible attack multiple times in the battle, the bonuses are cumulative.
+
+_Adventurer Feat_
+
+When you use this flexible attack, your animal companion’s crit range also expands by 2.
+
+_Champion Feat_
+
+The attack bonus is now +2 instead of +1.
+
+_**Epic Feat**_
+
+When you use this flexible attack, your animal companion also heals hit points equal to triple your Strength or Dexterity modifier.
+
+##### Resilience
+
+Flexible once-per battle melee attack
+
+**Triggering Roll:** Natural 1–5
+
+**Effect:** You gain 5 temporary hit points and _resist damage 12+_ against attacks that target AC until two attacks against you have had their damage halved from that resistance.
+
+_Adventurer Feat_
+
+The damage resistance also applies to attacks that target PD.
+
+_Champion Feat_
+
+You now gain 10 temporary hit points instead of 5, and the damage resistance increases to 14+.
+
+_Epic Feat_
+
+You now gain 15 temporary hit points instead of 10, and the damage resistance increases to 16+.
+
+##### Shillelagh
+
+Flexible once-per battle melee attack
+
+**Triggering Roll:** Natural 13
+
+**Effect:** If the target isn’t staggered after the attack, the attack is a critical hit. If the target is staggered after the attack, you can heal using a recovery and the target is stuck until the end of its next turn.
+
+_Adventurer Feat_
+
+This flexible attack now also triggers on a natural 3.
+
+_Champion Feat_
+
+The stuck effect is now save ends.
+
+_Epic Feat_
+
+This flexible attack now also triggers on a natural 17.
+
+##### Spirits of the Land
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Natural 18+
+
+**Effect:** During your next turn, you can cast a Terrain Caster at-will feat spell of your choice once as a quick action, even if you don’t normally know that spell. The spell must match a type of terrain you are in.
+
+_Adventurer Feat_
+
+If you also have the Terrain Caster talent, you gain a +2 attack bonus with that spell.
+
+_Champion Feat_
+
+Any other Terrain Caster spell you cast during your next turn also gains a +2 attack bonus.
+
+##### Strength of Earth
+
+Flexible once-per battle melee attack
+
+**Triggering Roll:** Natural even roll
+
+**Effect:** Each enemy engaged with you can’t attempt to disengage (save ends). They can still move away and take opportunity attacks, if they wish.
+
+##### Warrior’s Blessing
+
+Flexible once-per-battle melee attack
+
+**Triggering Roll:** Any natural even roll
+
+**Effect:** You heal hit points equal to your Strength or Dexterity modifier (double that modifier at 5th level; triple it at 8th level).
+
+_Adventurer Feat_
+
+Add 1d6 to the healing provided by this flexible attack.
+
+_Champion Feat_
+
+One nearby ally also gains the same amount of healing that you do from this flexible attack.
+
+_Epic Feat_
+
+Add 4d10 instead of 1d6 to the healing provided by this flexible attack, and you can use _warrior’s blessing_ twice per battle.
+
+##### Wild Harmony
+
+Flexible once-per battle melee attack
+
+**Triggering Roll:** Natural 16+
+
+**Effect:** If you cast a _regeneration_ or _greater regeneration_ spell before the start of your next turn, the target adds your Wisdom modifier to the healing they gain from their _first_ recovery roll (not subsequent rolls). (Double your Wisdom modifier at 5th level; triple it at 8th level).
+
+_Adventurer Feat_
+
+The target now adds the healing bonus to each recovery roll from that spell.
+
+_Champion Feat_
+
+This flexible attack now also triggers on any natural even roll.
+
+_Epic Feat_
+
+When this flexible attack triggers, you or one nearby conscious ally heal hit points equal to double your Wisdom modifier.
+
+### Wild Healer
+
+The Wild Healer talent provides you spell options as indicated on your level progression chart, with possible bonus spells provided by feats. _Regeneration_ is your main healing spell; you start with both a per-battle and daily use, and gain more uses as you level up. Wild Healer initiates and adepts get access to the _wild heal_ spell later in their career. G_reater regeneration_ is only available to adepts.
+
+The feats below are available to Wild Healer initiates and adepts.
+
+#### Adventurer Feat
+
+If you’re a Wild Healer initiate, you gain a daily use of the _wild heal_ spell. If you’re a Wild Healer adept, you instead gain a once-per-battle use of the _wild heal_ spell.
+
+#### Champion Feat
+
+You gain an additional daily use of _regeneration_.
+
+#### Epic Feat
+
+Once per day as a free action when a target of one of your _regeneration_ spells (or _greater regeneration_) fails the save to continue its regeneration, the target succeeds instead.
+
+#### Wild Healer Initiate Level Progression
+| Druid Level        | Per-battle regeneration spells | Daily regeneration spells | Daily greater regeneration spells | Daily wild heal spells |
+|--------------------|--------------------------------|---------------------------|-----------------------------------|------------------------|
+| Level 1 Multiclass | 1                              | —                         | —                                 | —                      |
+| Level 1            | 1                              | 1                         | —                                 | —                      |
+| Level 2            | 1                              | 1                         | —                                 | —                      |
+| Level 3            | 1                              | 1                         | —                                 | —                      |
+| Level 4            | 1                              | 1                         | —                                 | —                      |
+| Level 5            | 1                              | 1                         | —                                 | 1                      |
+| Level 6            | 1                              | 1                         | —                                 | 1                      |
+| Level 7            | 1                              | 2                         | —                                 | 1                      |
+| Level 8            | 1                              | 2                         | —                                 | 1                      |
+| Level 9            | 1                              | 2                         | —                                 | 2                      |
+| Level 10           | 1                              | 2                         | —                                 | 2                      |
+
+#### Wild Healer Adept Level Progression
+| Druid Level        | Per-battle regeneration spells | Daily regeneration spells | Daily greater regeneration spells | Daily wild heal spells |
+|--------------------|--------------------------------|---------------------------|-----------------------------------|------------------------|
+| Level 1 Multiclass | 1                              | —                         | —                                 | —                      |
+| Level1             | 1                              | 1                         | —                                 | 1                      |
+| Level 2            | 1                              | 1                         | 1                                 | 1                      |
+| Level 3            | 2                              | 1                         | 1                                 | 1                      |
+| Level 4            | 2                              | 1                         | 1                                 | 1                      |
+| Level 5            | 2                              | 2                         | 1                                 | 1                      |
+| Level 6            | 2                              | 2                         | 1                                 | 1                      |
+| Level 7            | 2                              | 2                         | 1                                 | 2                      |
+| Level 8            | 2                              | 2                         | 2                                 | 2                      |
+| Level 9            | 2                              | 3                         | 2                                 | 2                      |
+| Level 10           | 2                              | 3                         | 2                                 | 3                      |
+
+#### Regeneration
+
+Close-quarters spell
+
+**Special:** See level progression chart for usage per battle/day.
+
+Interrupt action or quick action
+
+**Target:** One nearby ally (with an interrupt action); or you (with a quick action)
+
+**Trigger (for targeted ally):** One of your allies starts its turn
+
+**Effect:** The target heals using a recovery, rolling recovery dice as normal, but heals only half (rounding down) the amount of healing rolled.
+
+At the start of the target’s _next_ turn, the target heals using a free recovery, but heals only half (rounding down) the amount rolled—the first recovery spent continues to fuel the _regeneration_ effect. After the target heals this second time, it rolls a normal save to see if the _regeneration_ spell will continue.
+
+If the save fails, the _regeneration_ spell ends.
+
+If the save succeeds, the _regeneration_ spell continues and the target will heal using a free recovery for half hit points again at the start of its next turn, and then roll another save to see if the _regeneration_ continues, and so on.
+
+_Special:_ The save to continue the _regeneration_ effect becomes a hard save (16+) if the target is at maximum hit points or if the target has dropped to 0 hit points or below while the _regeneration_ is in effect.
+
+**Special:** You can only have one _regeneration_ or _greater regeneration_ spell on you at a time. A second spell cast on you cancels the first.
+
+#### Greater Regeneration
+
+Close-quarters spell
+
+**Special:** See level progression chart for usage per battle/day.
+
+Interrupt action or quick action
+
+**Target:** One nearby ally (with an interrupt action); or you (with a quick action)
+
+**Trigger (for targeted ally):** One of your allies starts its turn
+
+**Effect:** The target heals using two recoveries but only rolls recovery dice as if it had used a single recovery.
+
+At the start of the target’s _next_ turn, the target heals using a free recovery—the two recoveries spent continue to fuel the _greater_ _regeneration_ effect. After the target heals this second time, it rolls a normal save to see if the _greater regeneration_ spell will continue.
+
+If the save fails, the _greater regeneration_ spell ends.
+
+If the save succeeds, the _greater regeneration_ spell continues and the target will heal using a free recovery again at the start of its next turn, and then roll another save to see if the _regeneration_ continues, and so on.
+
+_Special:_ The save to continue the _regeneration_ effect becomes a hard save (16+) if the target is at maximum hit points or if the target has dropped to 0 hit points or below while the _greater_ _regeneration_ is in effect.
+
+**Special:** You can only have one _regeneration_ or _greater regeneration_ spell on you at a time. A second spell cast on you cancels the first.
+
+#### Wild Heal
+
+Close-quarters spell
+
+Daily, see level progression chart for number of uses
+
+Quick action
+
+**Target:** You or one nearby ally, and one randomly chosen nearby ally that has taken damage
+
+**Effect:** Each target heals using one of its recoveries.
+
+## Animal Companion Rules
+
+You have a devoted animal companion who fights alongside you like a member of your adventuring party.
+
+If you have a single talent invested into Animal Companion, you are an Animal Companion initiate. If you invested two talents into Animal Companion, you are an Animal Companion adept.
+
+These are the same rules as for the ranger.
+
+### Calling to Battle
+
+When you roll initiative, you may choose whether you want your animal companion to take part in the battle. You may also call your animal companion during the battle with a quick action.
+
+Animal Companion initiates may only call their animal companion once every other battle. The animal companion may not fight in two battles in a row—even between full heal-ups, adventures, or gaining new levels. Animal Companion adepts don’t have this limitation; their animal companion can fight in every battle if the adept so chooses.
+
+### Recoveries
+
+As an initiate, add a recovery to your total recoveries. As an adept, add two recoveries to your total recoveries. You can use a recovery on yourself or your animal companion.
+
+### Actions
+
+Your animal companion acts on your initiative turn, either immediately before or after you, depending on the animal type.
+
+Your animal companion moves gets a move action and a standard action, but not a quick action.
+
+If you have powers that care about the “first time you attack an enemy,” an attack by your animal companion counts as your attack.
+
+### Animal Harm
+
+Your animal companion can be healed like an ally. If it gets healed without you being healed, it uses one of your recoveries. When you use a recovery while next to your animal companion (including being engaged with the same enemy), your animal companion is also healed using a free recovery.
+
+Instead of dying like a monster or NPC at 0 hp, your animal companion follows PC rules for falling unconscious at 0 hp and dying after four failed death saves or when its negative hit points equal half its normal hit points. If your animal companion dies, it’s gone for the battle, though you can call it (or another one) to fight in the next battle (as an adept) or the in the battle after that (as an initiate). That animal companion will be one level lower than an animal companion would normally be, i.e. two levels below you. At the start of the next battle, bump the animal companion up to its proper level, i.e. one below you.
+
+### Stats & Levels
+
+Each animal companion has roughly the same base stats as listed below.
+
+Your animal companion is always one level lower than you. As a 1st level druid, you’ll have a level 0 animal companion. Once you gain a level, your animal companion rises to 1st level.
+
+On top of the base stats, each type of animal has a zoologically appropriate power or advantage.
+
+### Companion Bonuses
+
+Each type of animal companion is a little different.
+
+#### Bear (also Giant Badger, Wolverine)
+
+**Acts:** After druid
+
+**Advantage:** The bear gains temporary hit points equal to its level each time it hits with an attack.
+
+#### Champion Feat
+
+The temporary hit points increase to double its level.
+
+#### Boar (also Spiky Lizard)
+
+**Acts:** Before druid
+
+**Advantage:** The boar gains a +1 attack bonus when it moves before its attack during the same turn.
+
+#### Eagle (also Falcon, Hawk, Owl, Vulture)
+
+**Acts:** Before druid
+
+**Advantage:** It flies! Its melee damage die is dropped by one size (d6 at level 0).
+
+#### Panther (also Lion, Tiger)
+
+**Acts:** Before druid
+
+**Advantage:** The panther’s crit range expands by 2 against enemies with lower initiative.
+
+#### Snake (also Giant Spider, Poison Toad)
+
+**Acts:** After druid
+
+**Advantage:** The snake also deals ongoing poison damage equal to twice your level on a natural attack roll of 18+.
+
+#### Champion Feat
+
+The ongoing damage is three times your level instead.
+
+#### Epic Feat
+
+The ongoing damage is four times your level instead.
+
+#### Wolf (also Big Dog, Coyote, Hyena, Jackal)
+
+**Acts:** After druid
+
+**Advantage:** The wolf gains a +1 attack bonus against enemies its master attacked the same turn, or against enemies engaged with its master.
+
+### Baseline Stats
+
+Use the following stats as the baseline for your animal companion. Remember that your companion stays a level lower than you. Generally your companion’s Physical Defense should be higher than its Mental Defense, but you could flip that if you have a good explanation.
+
+| Level | Attack     | Damage | AC  | PD (or MD) | MD (or PD) | HP        |
+| ----- | ---------- | ------ | --- | ---------- | ---------- | --------- |
+| 0     | +5 vs. AC  | d8     | 16  | 14         | 10         | 20 (10)   |
+| 1     | +6 vs. AC  | d10    | 17  | 15         | 11         | 27 (13)   |
+| 2     | +7 vs. AC  | 2d6    | 18  | 16         | 12         | 36 (18)   |
+| 3     | +9 vs. AC  | 3d6    | 19  | 17         | 13         | 45 (22)   |
+| 4     | +10 vs. AC | 4d6    | 21  | 19         | 15         | 54 (27)   |
+| 5     | +11 vs. AC | 5d6    | 22  | 20         | 16         | 72 (36)   |
+| 6     | +13 vs. AC | 6d6    | 23  | 21         | 17         | 90 (45)   |
+| 7     | +14 vs. AC | 7d6    | 25  | 23         | 19         | 108 (54)  |
+| 8     | +15 vs. AC | 8d6    | 26  | 24         | 20         | 144 (72)  |
+| 9     | +17 vs. AC | 9d6    | 27  | 25         | 21         | 180 (90)  | 
+| 10    | +18 vs. AC | 10d6   | 28  | 26         | 22         | 216 (108) |
+
+### Animal Companion Feats
+
+Druid animal companion feats are designed so that they do not build on each other. Unlike other feats, you don’t have to take animal companion feats progressively, one after the other as long as you qualify for the correct tier.
+
+#### Adventurer Feats
+
+-   Once per day, your animal companion can attack twice in a round with a standard action.
+    
+-   Once per battle, your animal companion can turn a disengage success by an enemy it is engaged with into a failure.
+    
+-   Once per day, reroll one of your animal companion’s missed attack rolls.
+    
+-   Your animal companion adds the escalation die to its attacks.
+    
+
+#### Champion Feats
+
+-   Once per day, your animal companion can force an enemy to reroll an attack that hit it.
+    
+-   Your Lethal Hunter talent also applies to your animal companion.
+    
+-   Increase your animal companion’s Physical Defense and Mental Defense by +1.
+    
+
+#### Epic Feats
+
+-   Increase your animal companion’s damage die by one size (for example, from d6s to d8s, or d8s to d10s).
+    
+-   Increase your animal companion’s AC by +1.
+    
+
+### Animal Companion Spells
+
+As an Animal Companion adept, you gain a number of spells to help your animal companion—or another’s—fight better. You don’t have to choose the spells you know ahead of time. You can cast any spell of your level or lower, limited only by the number of daily spells you get. Once you cast a particular daily spell, no matter its level, you can’t cast it again until you take your next full heal-up.
+
+Animal Companion spells are not available to Animal Companion initiates.
+| Druid Level | Multiclass Level | Daily Spells | Spells are Cast At |
+|-------------|------------------|--------------|--------------------|
+| 1           | 1, 2             | 1            | 1st level          |
+| 2           | 3                | 2            | 1st level          |
+| 3           | 4                | 2            | 3rd level          |
+| 4           | 5                | 2            | 3rd level          |
+| 5           | 6                | 3            | 5th level          |
+| 6           | 7                | 3            | 5th level          |
+| 7           | 8                | 3            | 7th level          |
+| 8           | 9                | 4            | 7th level          |
+| 9           | 10               | 4            | 9th level          |
+| 10          | -                | 4            | 9th level          |
+
+### 1st Level Spells
+
+#### Pack Link
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, when the target attacks an enemy that is engaged with you, increase the target’s melee attack damage dice for that attack by one size, up to a maximum of d12.
+
+5th level spell: The target’s basic melee attacks now deal half damage on a natural even miss.
+
+7th level spell: The target’s basic melee attacks now deal half damage on any miss.
+
+#### Vitality
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** The target heals using a free recovery.
+
+3rd level spell: In addition, the target heals hit points equal to your Wisdom modifier at the start of each of its turns until the end of the battle or until it drops to 0 hit points.
+
+5th level spell: The healing the target gains at the start of its turn is now double your Wisdom modifier.
+
+7th level spell: The healing the target gains at the start of its turn is now triple your Wisdom modifier.
+
+9th level spell: The first time this battle that the target drops to 0 hit points, you can roll a normal save. If you succeed, the target heals using one of your recoveries.
+
+### 3rd Level Spells
+
+#### Magic Fang
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** If the target already adds the escalation die to its attacks, it gains a +2 attack bonus until the end of the battle. If not, it now adds the escalation die to its attacks until the end of the battle.
+
+5th level spell: The target’s crit range expands by 2.
+
+9th level spell: The target’s crit range expands by a total of 4.
+
+### 5th Level Spells
+
+#### Armor of Shell & Spirits
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Special:** You must spend a recovery to cast this spell.
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, the target gains _resist damage 12+_ against attacks that target AC.
+
+7th level spell: Resistance now includes attacks that target PD.
+
+9th level spell: Resistance increases to _resist damage 14+._
+
+### 7th Level Spells
+
+#### Blood is Strong
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, when the target hits with a melee attack, you heal hit points equal to 1d10 + your Wisdom modifier.
+
+9th level spell: You now heal hit points equal to 2d10 + double your Wisdom modifier.
+
+### 9th Level Spells
+
+#### Spirit Guardian
+
+Ranged spell
+
+Free action to cast
+
+Daily
+
+**Special Trigger:** You drop to 0 hp or below while your animal companion is nearby and still above 0 hp.
+
+**Effect:** Your spirit trades places with the spirit of your animal companion. You now occupy the body of your animal companion, using its current hit points, defenses, and attacks (and the effects of any spells cast upon it earlier).
+
+You can’t cast spells or use your normal humanoid powers and class features while in your companion’s body. You can either keep fighting as your animal companion or you can roll a normal save as a quick action once during each of your turns; if you succeed, your body and your animal companion's body swap places while your spirits return to their proper bodies. You keep the hit points of the animal companion before you rolled the save, but can heal using a recovery when the swap is complete, if you wish. Returning to your own partially-healed body thanks to the successful save ends the spell's effect.
+
+While your animal companion is in your body, it can roll death saves and be healed. If it becomes conscious it can attack using its basic melee attacks, but it doesn’t have access to any of your spells or powers. Any failed death saves remain with the spirit that failed them, not the body.

--- a/Classes/Fighter.md
+++ b/Classes/Fighter.md
@@ -1,0 +1,607 @@
+---
+aliases: [Fighter]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Fighter]
+updated:: 2023-05-07
+---
+
+# Ability Scores
+
+Fighters gain a +2 class bonus to Strength or Constitution, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+# Backgrounds
+
+Possible backgrounds include: swordmaster, mercenary captain, sea raider, shieldwall spearman, explorer, bouncer, thug, city guardsman, former gladiator, former orc captive, bankrupt nobleman, duelist, and goblin-hunter.
+
+# Gear
+
+At 1st level, a fighter starts with a melee weapon or two, a ranged weapon if they want it, armor, and standard non-magical gear that is suggested by the character’s backgrounds.
+
+## Gold Pieces
+
+Fighters may start with either 25 gp or 1d6 x 10 gp.
+
+## Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 13      | —           |
+| Heavy      | 15      | —           |
+| Shield     | 1       | —           |
+
+## Melee Weapons
+
+|                  | One-Handed               | Two-Handed                |
+| ---------------- | ------------------------ | ------------------------- |
+| Small            | 1d4 dagger               | 1d6 club                  |
+| Light or Simple  | 1d6 shortsword, hand axe | 1d8 spear                 |
+| Heavy or Martial | 1d8 longsword, warhammer | 1d10 greatsword, greataxe |
+
+## Ranged Weapons
+
+|                  | Thrown           | Crossbow           | Bow          |
+| ---------------- | ---------------- | ------------------ | ------------ |
+| Small            | 1d4 dagger       | 1d4 hand crossbow  | —            |
+| Light or Simple  | 1d6 javelin, axe | 1d6 light crossbow | 1d6 shortbow |
+| Heavy or Martial | —                | 1d8 heavy crossbow | 1d8 longbow  |
+
+# Level Progression
+
+| Fighter Level      | Total Hit Points           | Total Feats                    | Maneuvers Known (M) | Maneuver Pool Available (M) | Class Talents | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|---------------------|-----------------------------|---------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                   | 3                   | 1st level                   | 3             | Not affected             | ability modifier                |
+| Level 1            | (8 + CON mod) x 3          | 1 adventurer                   | 3                   | 1st level                   | 3             |                          | ability modifier                |
+| Level 2            | (8 + CON mod) x 4          | 2 adventurer                   | 4                   | 1st level                   | 3             |                          | ability modifier                |
+| Level 3            | (8 + CON mod) x 5          | 3 adventurer                   | 4                   | 3rd level                   | 3             |                          | ability modifier                |
+| Level 4            | (8 + CON mod) x 6          | 4 adventurer                   | 5                   | 3rd level                   | 3             | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (8 + CON mod) x 8          | 4 adventurer 1 champion        | 5                   | 5th level                   | 3             |                          | 2 x ability modifier            |
+| Level 6            | (8 + CON mod) x 10         | 4 adventurer 2 champion        | 6                   | 5th level                   | 4             |                          | 2 x ability modifier            |
+| Level 7            | (8 + CON mod) x 12         | 4 adventurer 3 champion        | 6                   | 7th level                   | 4             | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (8 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 7                   | 7th level                   | 4             |                          | 3 x ability modifier            |
+| Level 9            | (8 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 7                   | 9th level                   | 4             |                          | 3 x ability modifier            |
+| Level 10           | (8 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 8                   | 9th level                   | 4             | +1 to 3 abilities        | 3 x ability modifier            |
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+Fighter weapon attack maneuvers deal damage based on the fighter’s level. You also don’t have to keep track of upgrading a 1st level maneuver into a 3rd level maneuver, because all the maneuvers function at your level. You can change which maneuvers you know and have ready whenever you gain a level.
+
+# Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus                        | +2 Strength or Constitution (different from racial bonus)    |
+|--------------------------------------|--------------------------------------------------------------|
+| Initiative                           | Dex mod + Level                                              |
+| Armor Class (heavy armor)            | 15 + middle mod of Con/Dex/Wis + Level                       |
+| Armor Class (shield and heavy armor) | 16 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense                     | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense                       | 10 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                           | (8 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                           | 9                                                            |
+| Recovery Dice                        | (1d10 x Level) + Con mod                                     |
+| Backgrounds                          | 8 points, max 5 in any one background                        |
+| Icon Relationships                   | 3 points                                                     |
+| Talents                              | 3 (see level progression chart)                              |
+| Feats                                | 1 per Level                                                  |
+| Ability Bonus                        | +2 Strength or Constitution (different from racial bonus)    |
+
+# Basic Attacks
+
+## Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+## Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+# Class Features
+
+Fighters have two class features: Extra Tough and Threatening.
+
+## Extra Tough
+
+You start with nine recoveries instead of the usual eight.
+
+### Adventurer Feat
+
+Increase your total recoveries by 1.
+
+## Threatening
+
+Whenever an enemy attempts to disengage from you, it takes a penalty to its check equal to your Dexterity or Constitution modifier, whichever is higher.
+
+The penalty doesn’t apply if you are stunned, grabbed, or otherwise incapable of making an opportunity attack.
+
+### Adventurer Feat
+
+Whenever an enemy fails to disengage from you, you also deal damage to that enemy equal to your Dexterity or Constitution modifier. At 5th level, damage is double the modifier. At 8th level, it’s triple.
+
+### Champion Feat
+
+Whenever a non-mook enemy fails to disengage from you, it’s vulnerable to your attacks for the rest of the battle.
+
+# Class Talents
+
+Choose three of the following class talents.
+
+You get an additional fighter class talent at 6th level.
+
+Fighters have flexible attacks called maneuvers; you roll your attack and then choose which maneuver you want the attack to use. You only get to use one maneuver with each attack, so it’s usually best to choose maneuvers with a few different triggering rolls
+
+## Cleave
+
+Once per battle, make a fighter melee attack as a free action after one of your melee attacks drops an enemy to 0 hp.
+
+### Adventurer Feat
+
+If you have your move action available, you can use it before making your Cleave attack to reach an enemy you are not already engaged with.
+
+### Champion Feat
+
+You can use Cleave twice each battle, but only once a round.
+
+### Epic Feat
+
+You gain a +4 attack bonus with your Cleave attacks.
+
+## Comeback Strike
+
+Once per battle as a free action, make another attack with a –2 penalty after your first fighter attack during your turn misses.
+
+### Adventurer Feat
+
+You no longer take the –2 penalty to your Comeback Strike attacks.
+
+### Champion Feat
+
+Once per day, you can use Comeback Strike twice in a battle.
+
+### Epic Feat
+
+You gain a +4 attack bonus with your Comeback Strike attacks.
+
+## Counter-Attack
+
+Once per round when the escalation die is even and an enemy misses you with a natural odd melee attack roll, you can make a basic melee attack dealing half damage against that enemy as a free action. (The attack can’t use any limited abilities or flexible attack maneuvers.)
+
+### Adventurer Feat
+
+Your Counter-Attack attack now deals full damage.
+
+### Champion Feat
+
+You can use Counter-Attack once per turn instead of once per round (in effect, you’re free to Counter-Attack once per enemy turn).
+
+### Epic Feat
+
+You can now use Counter-Attack when the escalation die is 3+.
+
+## Deadeye Archer
+
+Your attacks with d8 ranged weapons (heavy crossbow, longbow) now deal d10 damage per level. Your attacks with d6 ranged weapons (light crossbow, shortbow) now deal d8 damage per level. In addition, your misses with basic ranged attacks deal damage equal to your level.
+
+### Adventurer Feat
+
+If you spend a quick action to aim before making a ranged basic attack, add your Dexterity modifier to the damage if you miss.
+
+### Champion Feat
+
+Once per battle, expand your crit range with a fighter ranged attack by 4 (usually to 16+) for that attack. Declare you’re using this feat power before you roll the attack.
+
+### Epic Feat
+
+Your crit range with ranged weapon attacks expands by 1 (usually to 19+).
+
+## Heavy Warrior
+
+Once per battle while wearing heavy armor, when you are hit by an attack that targets AC, as a free action, you can take half damage from that attack instead.
+
+### Adventurer Feat
+
+Once per day, you can use Heavy Warrior twice in a battle (against different attacks).
+
+### Champion Feat
+
+You can also use the power against an attack that targets PD.
+
+### Epic Feat
+
+Once per day, you can reroll a recharge roll for a magic armor power.
+
+  
+  
+
+## Power Attack
+
+Once per battle before you roll an attack, you can declare you’re using Power Attack to deal additional damage with that attack roll. If the attack hits, you deal the following additional damage:
+
+Deal 1d4 additional damage per level if you are using a one-handed weapon.
+
+Deal 1d6 additional damage per level if you are using a two-handed weapon.
+
+### Adventurer Feat
+
+You deal the additional Power Attack damage even if the attack misses.
+
+### Champion Feat
+
+One battle per day, you can use Power Attack twice in the battle.
+
+### Epic Feat
+
+One-handed weapon damage using Power Attack increases to 1d6 per level; two-handed weapon damage using Power Attack increases to 1d8 per level.
+
+## Skilled Intercept
+
+Once per round as a free action, roll a normal save (11+) to intercept an enemy who is moving to attack one of your nearby allies. You can pop free from one enemy to move and intercept the attack. If you are engaged with more than one enemy, the others can take opportunity attacks against you.
+
+The moving enemy makes its attack with you as a target instead. If you’re wearing heavy armor and the attack hits, you only take half damage.
+
+### Adventurer Feat
+
+You can pop free from up to two enemies when using Skilled Intercept.
+
+### Champion Feat
+
+You gain a bonus to your Skilled Intercept save equal to the escalation die.
+
+### Epic Feat
+
+Enemies can’t make opportunity attacks against you during your Skilled Intercept movement.
+
+## Tough as Iron
+
+Once per battle, you can rally using a quick action instead of a standard action.
+
+### Adventurer Feat
+
+Once per day, you can rally twice during a battle as a quick action, without needing to roll a save for the second rally.
+
+### Champion Feat
+
+Increase your total number of recoveries by 2.
+
+### Epic Feat
+
+When you roll a natural 20 with an attack, you gain an additional use of Tough As Iron this battle.
+
+# 1st Level Maneuvers
+
+## Brace for It
+
+Flexible melee attack
+
+**Triggering Roll:** Any miss
+
+**Effect:** Until the end of your next turn, the first critical hit you take from a melee attack becomes a normal hit instead.
+
+### Adventurer Feat
+
+_Brace for it_ now works against a critical hit from any type of attack.
+
+### Champion Feat
+
+_Brace for it_ works against any number of critical hits before your next turn.
+
+## Carve an Opening
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural odd roll
+
+**Effect:** Your crit range with melee attacks expands by a cumulative +1 this battle until you score a melee critical hit. When you score a melee critical hit, your crit range drops back to normal.
+
+### Champion Feat
+
+The crit range bonus from carve an opening is +2 instead of +1.
+
+## Deadly Assault
+
+Flexible melee or ranged attack
+
+**Triggering Roll:** Any natural even hit
+
+**Effect:** Reroll any 1s from your damage roll. You’re stuck with the rerolls.
+
+### Adventurer Feat
+
+Now you can reroll both 1s and 2s with deadly assault.
+
+### Champion Feat
+
+_Deadly assault_ now also triggers on a natural 17+.
+
+## Defensive Fighting
+
+Flexible melee attack
+
+**Triggering Roll:** Natural 16+; if you fight with a shield, also any natural even roll
+
+**Effect:** Gain a +2 bonus to AC until the end of your next turn.
+
+### Adventurer Feat
+
+You also gain the bonus to Physical Defense.
+
+### Champion Feat
+
+The bonus increases to +3.
+
+### Epic Feat
+
+You also gain the bonus to Mental Defense.
+
+## Grim Intent
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural even miss
+
+**Effect:** The next time you would deal miss damage with a melee attack, add a WEAPON die to that damage. At 5th level, instead add 2 total WEAPON dice; at 8th level, instead add 3 total WEAPON dice.
+
+## Heavy Blows
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural even miss
+
+**Effect:** You gain a bonus to your miss damage with that attack equal to the escalation die.
+
+### Champion Feat
+
+If you attacked with a two-handed weapon, _heavy blows_ can trigger on any miss, odd or even.
+
+### Epic Feat
+
+The bonus instead equals double the escalation die with a one-handed weapon, or triple it with a two-handed weapon.
+
+## Precision Attack
+
+Flexible melee attack
+
+**Triggering Roll:** Any hit with a natural 16+
+
+**Effect:** You gain a bonus to the damage roll equal to your Dexterity modifier. At 5th level, the damage bonus increases to double your Dexterity modifier; at 8th level the damage bonus increases to triple it.
+
+### Adventurer Feat
+
+You can now use _precision attack_ with a ranged attack.
+
+Second Shot
+
+Flexible ranged attack
+
+**Triggering Roll:** Natural 16+
+
+**Effect:** After this attack, you can make a basic ranged attack with the same weapon (as long as it’s not a weapon that takes a quick action to reload or draw) with a –4 attack penalty.
+
+You can’t use any maneuvers with the second attack.
+
+### Champion Feat
+
+The _second shot_ attack penalty is –2 instead.
+
+## Shield Bash
+
+Flexible melee attack
+
+**Special:** You must be using a shield.
+
+**Triggering Roll:** Any natural even roll
+
+**Effect:** The target pops free from you after the attack (does not allow opportunity attacks).
+
+### Adventurer Feat
+
+If the target is also engaged with any of your allies, you can have it pop free from them as well.
+
+### Champion Feat
+
+Once per battle, you can also daze the target (save ends) of your shield bash attack, if that enemy is staggered.
+
+## Two-Weapon Pressure
+
+Flexible melee attack
+
+**Special:** You must be using a weapon in each hand.
+
+**Triggering Roll:** Any miss
+
+**Effect:** Until the end of your next turn, you gain a +2 melee attack bonus against the target.
+
+### Champion Feat
+
+The bonus increases to +4.
+
+# 3rd Level Maneuvers
+
+## Hack & Slash
+
+Flexible melee attack
+
+**Special:** You can use this maneuver only once per round.
+
+**Triggering Roll:** Any natural even roll, when the escalation die is 2+
+
+**Effect:** Make another melee weapon attack against a different target.
+
+## Make ’em Flinch
+
+Flexible ranged attack
+
+**Triggering Roll:** Any natural even miss
+
+**Effect:** Add the higher modifier from your Strength or Dexterity to the miss damage. At 5th level the damage bonus increases to double your chosen modifier; at 8th level the damage bonus increases to triple it.
+
+## Punish Them
+
+Flexible melee attack
+
+**Special:** You can use this maneuver only when you make an opportunity attack.
+
+**Triggering Roll:** Any hit with a natural 16+
+
+**Effect:** The target is dazed until the end of its turn.
+
+### Adventurer Feat
+
+If the target was moving, it stops moving and loses the rest of its move action.
+
+### Champion Feat
+
+The dazed effect is now save ends.
+
+### Epic Feat
+
+The target is now weakened (save ends) instead of dazed.
+
+## Steady Now
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural even miss
+
+**Effect:** You gain temporary hit points equal to your Constitution modifier.
+
+### Champion Feat
+
+The temporary hit points increase to double your Constitution modifier.
+
+## Strong Guard
+
+Flexible melee attack
+
+**Special:** You must be using a shield.
+
+**Triggering Roll:** Any miss
+
+**Effect:** One ally next to you (including an ally engaged with the same enemy as you) gains a +2 AC bonus until the start of your next turn or until you are no longer next to them.
+
+### Champion Feat
+
+Bonus also applies to PD.
+
+### Epic Feat
+
+Bonus increases to +3.
+
+# 5th Level Maneuvers
+
+## A Dozen Cuts
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural even hit
+
+**Effect:** The target also takes ongoing damage equal to double your Dexterity modifier, or triple it at 8th level.
+
+### Champion Feat
+
+Once per battle, you can trigger _a dozen cuts_ with a natural odd hit.
+
+## Hero’s Skill
+
+Flexible melee or ranged attack
+
+**Triggering Roll:** Any natural even miss
+
+**Effect:** Add +2 to the attack roll, then halve any damage dealt by the attack if it hits.
+
+### Champion Feat
+
+Add +4 to the attack roll instead of +2.
+
+### Epic Feat
+
+The damage is no longer halved on a hit after using _hero’s skill_.
+
+## Sword Master’s Anticipation
+
+Flexible melee attack
+
+**Special:** You must have the Skilled Intercept talent to use this maneuver.
+
+**Triggering Roll:** Any natural even roll
+
+**Effect:** The next time you use Skilled Intercept this battle, your Skilled Intercept save automatically succeeds.
+
+# 7th Level Maneuvers
+
+## Never Surrender
+
+Flexible melee attack
+
+**Triggering Roll:** Any natural even roll
+
+**Effect:** You can roll a save against a save ends effect.
+
+### Epic Feat
+
+You gain a +2 bonus to the save.
+
+## Spinning Charge
+
+Flexible melee attack
+
+**Special:** You must have moved before the attack.
+
+**Triggering Roll:** Any natural even hit
+
+**Effect:** After dealing damage, you can pop free from the target, move to a different nearby enemy, and make a basic melee attack against that enemy.
+
+You can’t use any maneuvers with the second attack, and it deals only half damage.
+
+### Epic Feat
+
+If the escalation die is 3+, the second _spinning charge_ attack deals full damage.
+
+## Sword of Destiny
+
+Flexible melee attack
+
+**Triggering Roll:** Natural 20
+
+**Effect:** You can heal using a free recovery.
+
+### Epic Feat
+
+If the escalation die is 3+, you can now trigger _sword of destiny_ with a natural 18+.
+
+# 9th Level Maneuvers
+
+## Combat Mastery
+
+Flexible melee attack
+
+**Special:** You can use this maneuver only once per battle.
+
+**Triggering Roll:** Natural 16+
+
+**Effect:** Increase the escalation die by 1.
+
+### Epic Feat
+
+_Combat mastery_ now also triggers on any natural even hit.
+
+## Set ’em Up
+
+Flexible melee attack
+
+**Triggering Roll:** Any hit with a natural 16+
+
+**Effect:** The crit range of your attacks against the target expands by 3 (generally 17+) until the end of the battle (cumulative).
+
+### Epic Feat
+
+The crit range bonus from _set ’em up_ now also applies to any ally who attacks the target while you are engaged with it.

--- a/Classes/Monk.md
+++ b/Classes/Monk.md
@@ -1,0 +1,1172 @@
+---
+aliases: [Monk]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Monk]
+updated:: 2023-05-07
+---
+
+### Ability Scores
+
+Monks gain a +2 class bonus to two of: Strength, Dexterity, or Wisdom, as long one of them isn’t the same ability you increase with your +2 racial bonus.
+
+### Backgrounds
+
+Possible backgrounds include: holy acolyte, mountain sanctuary guardsman, traveling circus acrobat, river guide, spider-cult assassin, tunnel vermin exterminator, bodyguard, farmer, hallucinogenic mushroom farmer, wild mountain ginseng harvester, traveling tournament organizer, civil rights organizer.
+
+### Gear
+
+At 1st level, a monk may start with one or two weapons, a change of clothes, and perhaps a ranged weapon—or none of those.
+
+#### Gold Pieces
+
+Monks may start with either 25 gp or 1d6 x 10 gp.
+
+#### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 11      | —           |
+| Light      | 11      | —           |
+| Heavy      | 12      | -4          |
+| Shield     | 1       | -2          |
+
+#### Melee Weapons
+
+A monk usually fights with his hands and feet (JAB, PUNCH, and KICK), though if he has traditional weapons from his training, he can use those. When a monk fights with weapons not from his tradition, he uses the fighter’s weapon chart with a -2 atk penalty.
+
+#### Ranged Weapons
+
+|                  | Thrown           | Crossbow                    | Bow                   |
+| ---------------- | ---------------- | --------------------------- | --------------------- |
+| Small            | 1d4 dagger, star | 1d4 (-2 atk) hand crossbow  | —                     |
+| Light or Simple  | 1d6 javelin      | 1d6 (-3 atk) light crossbow | 1d6 (-2 atk) shortbow |
+| Heavy or Martial | —                | 1d8 (-4 atk) heavy crossbow | 1d8 (-3 atk) longbow  |
+
+### Level Progression
+
+| Monk               | Total Hit Points           | Total Feats                    | Class Talents (M)              | Forms (M)                      | Ki (M)      | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|--------------------------------|--------------------------------|-------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | 1 or 2 adventurer (3 total)    | 2 adventurer                   | 0 + Wis mod | Not affected             | ability modifier                |
+| Level 1            | (7 + CON mod) x 3          | 1 adventurer                   | 3 adventurer                   | 2 adventurer                   | 1 + Wis mod |                          | ability modifier                |
+| Level 2            | (7 + CON mod) x 4          | 2 adventurer                   | 3 adventurer                   | 2 adventurer                   | 2 + Wis mod |                          | ability modifier                |
+| Level 3            | (7 + CON mod) x 5          | 3 adventurer                   | 3 adventurer                   | 3 adventurer                   | 2 + Wis mod |                          | ability modifier                |
+| Level 4            | (7 + CON mod) x 6          | 4 adventurer                   | 3 adventurer                   | 3 adventurer                   | 2 + Wis mod | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (7 + CON mod) x 8          | 4 adventurer 1 champion        | 3 adventurer                   | 3 adventurer,1 champion        | 3 + Wis mod |                          | 2 x ability modifier            |
+| Level 6            | (7 + CON mod) x 10         | 4 adventurer 2 champion        | 3 adventurer 1 champion        | 3 adventurer 1 champion        | 3 + Wis mod |                          | 2 x ability modifier            |
+| Level 7            | (7 + CON mod) x 12         | 4 adventurer 3 champion        | 3 adventurer 1 champion        | 2 adventurer 2 champion        | 3 + Wis mod | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (7 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 3 adventurer 1 champion        | 2 adventurer 2 champion 1 epic | 3 + Wis mod |                          | 3 x ability modifier            |
+| Level 9            | (7 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 3 adventurer 1 champion 1 epic | 2 adventurer 2 champion 1 epic | 3 + Wis mod |                          | 3 x ability modifier            |
+| Level 10           | (7 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 3 adventurer 1 champion epic   | 2 adventurer 2 champion 2 epic | 3 + Wis mod | +1 to 3 abilities        | 3 x ability modifier            |
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+### Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus                | +2 Strength, Dexterity, or Wisdom in two scores (different from racial bonus) |
+|------------------------------|-------------------------------------------------------------------------------|
+| Initiative                   | Dex mod + Level                                                               |
+| Armor Class (no/light armor) | 11 + middle mod of Con/Dex/Wis + Level                                        |
+| Physical Defense             | 11 + middle mod of Str/Con/Dex + Level                                        |
+| Mental Defense               | 11 + middle mod of Int/Wis/Cha + Level                                        |
+| Hit Points                   | (7 + Con mod) x Level modifier (see level progression chart)                  |
+| Recoveries                   | 8                                                                             |
+| Recovery Dice                | (1d8 x level) + Con mod                                                       |
+| Backgrounds                  | 8 points, max 5 in any one background                                         |
+| Icon Relationships           | 3 points (4 at 5th level; 5 at 8th level)                                     |
+| Talents                      | 3 (see level progression chart)                                               |
+| Feats                        | 1 per Level                                                                   |
+| Feats                        | 1 per Level                                                                   |
+| Ability Bonus                | +2 Strength or Constitution (different from racial bonus)                     |
+
+  
+
+### Basic Attacks
+
+#### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** PUNCH + Strength damage
+**Miss:** Damage equal to your level
+
+#### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+### Class Features
+
+All monks have attacks dealing JAB, PUNCH, and KICK damage, use forms as the basis of their actions during each round, use ki points, and are considered to fight with two-weapons even when they’re just fighting with their fists and feet. They also can take advantage of magical bracers.
+
+#### JAB, PUNCH, and KICK Attacks
+
+Under normal circumstances, melee weapons that are traditional in a monk’s style function like special effects for monks. Most monk attacks are rated as JAB, PUNCH, or KICK attacks, in the same sense that most fighter attacks are WEAPON attacks.
+
+-   JAB attacks deal 1d6 damage per level.
+    
+-   PUNCH attacks deal 1d8 damage per level.
+    
+-   KICK attacks deal 1d10 damage per level.
+    
+
+Monks don’t use weapon damage dice unless they are using a non-traditional weapon or a basic ranged attack that is not part of one of their monk forms.
+
+When fighting barehanded, with bracers, or with traditional monk weapons, monks use damage dice based on the form they are attacking with, or PUNCH damage for basic melee attacks. While using a magic weapon, monks add the weapon’s attack and damage bonus to their attacks, and they can use that weapon’s power(s).
+
+All monk attacks that use Dexterity as the attack stat use Strength as the ability score that determines damage.
+
+#### Forms
+
+When you learn a monk form, you learn all three elements of that form: an **opening attack**, **flow attack**, and **finishing attack**. Each element generally requires a standard action to use.
+
+Your first standard action attack in a battle must be an opening. Your second attack can be a flow attack from any form you know, or it can be another opening. After you use a flow attack, your next monk attack must be a finishing attack from any form you know, or it can be another opening. (You can’t use flow attack twice in a row.) After a finishing attack you must start over with an opening on your next standard action. If you do not attack one turn, you must start over with an opening on your next standard action. This form progression applies whether you hit or miss with your attack.
+
+As long as you use the proper element of the form (opening, flow, or finishing attack), you can use an opening, flow, or finishing attack from ANY of the forms you know.
+
+When you use an element of a form, you gain an AC bonus until the start of your next turn. After using an opening attack you gain a +1 bonus to AC. After using a flow attack, you gain a +2 bonus to AC. After using a finishing attack, you gain a +3 bonus to AC. If _elven grace_ or some other power lets you use multiple elements of your forms in a turn, the AC bonuses don’t stack but you do get to use the highest bonus.
+
+#### Ki
+
+You gain a number of _ki_ points each day equal to 1 + your Wisdom modifier. You can spend ki to modify the natural result of one of your attack rolls. Ki is a daily resource. When you take a full heal-up, you regain all your ki points. You don’t regain ki during a quick rest.
+
+After rolling an attack, you can spend 1 point of ki as a free action to change your attack’s _natural_ result by 1, unless that result is a natural 1. The change can be +1 or -1. Spending ki is a free action, but you can only spend 1 point of ki each turn.
+
+##### Adventurer Feat
+
+You gain 1 additional point of ki each day.
+
+##### Champion Feat
+
+You can spend as much ki as you like during a turn. You must spend each point of ki on a different attack roll or a different ki power.
+
+##### Epic Feat
+
+Work with your GM to invent a new ki power related to your one unique thing or some other aspect of your character’s story. If the ki power is too good and overshadows your other ki powers, the GM should rule that you can only use it once a day.
+
+#### Two-Weapon Fighting
+
+Since monks are trained to strike with all their limbs, they can always be considered to be fighting with two weapons in melee, even when they’re barehanded. The principal advantage of “two-weapon fighting” is that you get to reroll your attack when you roll a natural 2 with a melee attack, sticking with the reroll.
+
+#### Bracers as Magic Items
+
+Monks get magic-weapon style powers from magical bracers. In practice, a monk fighting barehanded looks to bracers for magical advantage. A monk who fights with the monastery’s traditional weapons might use bracers or a magical weapon, but a monk wearing magical bracers can’t use a magical melee weapon at the same time.
+
+### Adventure Tier Talents
+
+Choose three of the following adventurer-tier class talents. You get an additional monk class talent at 6th level and 9th level.
+
+You are free to take as many of the Seven Deadly Secrets talents as you wish (up to the class limit) but you can only use one of them per battle. You can choose which one just before using it.
+
+#### Flurry (Seven Deadly Secrets)
+
+_If you use_ Flurry _in a battle, you can’t use any other_ Deadly Secrets _talents that battle._
+
+You gain the following attack:
+
+Melee attack
+
+At-Will (once per round), when the escalation die is 3+
+
+Quick action
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage
+
+**Miss:** —
+
+##### Adventurer Feat
+
+You can now use Flurry when the escalation die is 2+.
+
+##### Champion Feat
+
+Your Flurry attack now deals damage equal to your level on a miss.
+
+##### Epic Feat
+
+When the escalation die is 4+, your Flurry attack deals PUNCH + Strength damage instead of JAB + Strength.
+
+##### Ki Power
+
+_(A Thousand Palms)_: You must be engaged with 2 or more enemies to use this power. After making a Flurry attack, you can spend 1 point of ki to make another Flurry attack against a target you have not already attacked with Flurry this turn.
+
+#### Greeting Fist (Seven Deadly Secrets)
+
+_If you use_ Greeting Fist _in a battle, you can’t use any other_ Seven Deadly Secrets _talent that battle._
+
+The first time you make a melee attack against each enemy during a battle (including the first mook of a mob), the target takes 1d8 extra damage on a hit.
+
+2nd level monk: 2d6 extra damage.
+
+4th level monk: 2d8 extra damage.
+
+6th level monk: 4d6 extra damage.
+
+8th level monk: 4d10 extra damage.
+
+10th level monk: 6d12 extra damage.
+
+##### _Adventurer Feat_
+
+Once per battle when you miss with your first melee attack against an enemy, you can use Greeting Fist against that enemy later that battle.
+
+##### _Champion Feat_
+
+When you successfully disengage from an enemy, that enemy takes damage equal to your level. Popping free doesn’t count; the damage only applies when you use the disengage action. (This damage doesn’t count as an attack, so if you hadn’t attacked that enemy yet, you could still use Greeting Fist on it later.)
+
+##### _Epic Feat_
+
+Once per battle, reroll an attack that qualified for Greeting Fist damage.
+
+##### Ki Power
+
+_(Opening the Death Gate)_: When you deal Greeting Fist damage, you can spend 1 point of ki to double that damage (as usual, a crit would then triple that damage).
+
+#### Temple Weapon Master (Seven Deadly Secrets)
+
+_If you use_ Temple Weapon Master _in a battle, you can’t use any other_ Seven Deadly Secrets _talents that battle._
+
+Once per battle while you’re fighting with a weapon or weapons associated with your monastic tradition, you can turn a natural even miss into a hit.
+
+##### Ki Power
+
+(_Supreme Warrior Discipline)_: When you use your Temple Weapon Master power, you can spend 1 point of ki to gain a bonus to AC equal to the _current_ escalation die until an attack against AC misses you or until the end of the battle. (The AC bonus increases or decreases as the escalation die increases or decreases.)
+
+###### _Adventurer Feat_
+
+The AC bonus from the ki power also applies to your PD. An attack against your PD that misses also ends the bonus.
+
+###### _Champion Feat_
+
+When you roll a natural 2 with a monk attack while fighting with your monastic weapons, in addition to the reroll you get from Two-Weapon Fighting, you gain a bonus to the rerolled attack equal to your Strength modifier or your Wisdom modifier.
+
+###### _Epic Feat_
+
+One battle per day, the damage dice of your finishing attacks increase by one size (max d12). (For example, d10s become d12s.)
+
+#### Diamond Focus
+
+You gain a +2 bonus to saves while you’re not staggered.
+
+In addition, you can go one round without using a monk attack form and still maintain your place in the attack form progression. For example, if you made an opening attack last round but don’t attack this round (or with your next standard action) for any reason, even being stunned or unconscious, you can still use a flow attack with your next standard action.
+
+##### Ki Power
+
+_(Diamond Soul)_: When you are dazed, weakened, or stunned, you can spend 1 point of ki to make an immediate normal save (11+). If you succeed, the effect ends. If you fail, the condition affects you normally. (This power also works on effects that aren’t save ends. It also breaks the stunned rule by letting you use a free action to spend ki.)
+
+###### Adventurer Feat
+
+You can also use the ki power to save when you’re confused or hampered.
+
+###### Champion Feat
+
+The ki power save is now an easy save (6+).
+
+###### Epic Feat
+
+You can also use the ki power to save against a last gasp effect (but it doesn’t count against your total if you fail).
+
+#### Heaven’s Arrow
+
+Unlike other monks, you have no attack penalty with ranged weapons, including thrown weapons, longbows, shortbows, and crossbows. Your basic ranged attacks also deal miss damage equal to your level.
+
+Once per battle when you would make a melee attack as an element of one of your monk forms, you can use a ranged attack against a nearby enemy instead. This attack deals damage according to the JAB/PUNCH/KICK hierarchy that’s part of the form rather than WEAPON damage like basic attacks.
+
+##### Ki Power
+
+(_Wind from Heaven_): You can spend 1 point of ki to regain your Heaven’s Arrow power when it’s expended.
+
+###### Adventurer Feat
+
+You can now target enemies that are faraway when you use the Heaven’s Arrow power. The ranged weapon you’re using might have an attack penalty against faraway enemies, but your attack otherwise functions as normal.
+
+###### Champion Feat
+
+You can now use the Heaven’s Arrow power twice per battle.
+
+###### Epic Feat
+
+You no longer take opportunity attacks when you make ranged attacks while engaged.
+
+#### Leaf on Wind
+
+Once per battle when you use a move action, you can take another move action as a free action.
+
+In addition, if you fall with a wall, tree, or other physical object next to you, you can fall up to 30 feet per level without taking damage. (You slap the surface, catch handholds, and use other maneuvers to slow your descent.)
+
+##### Ki Power
+
+_(Wind’s Comrade)_: You can spend 1 point of ki during your turn to gain _flight_ until the end of your turn.
+
+###### Adventurer Feat
+
+You gain a +3 bonus to disengage checks.
+
+###### Champion Feat
+
+When an enemy makes an attack against you that targets more than one creature, you only take half damage from that attack, hit or miss.
+
+###### Epic Feat
+
+Roll a normal save at the end of any turn in which you use the ki power. If you succeed, your _flight_ lasts until the end of your next turn. (It’s not advisable to count on this working by staying in midair, though you could of course fly next to a wall, counting on your ability to slow your fall as outlined above!)
+
+#### Overworld Lineage, aka Phoenix-touched
+
+If you wish, any time an element of the monk class refers to Wisdom, you can replace that element with a reference to Charisma.
+
+In addition, while you’re staggered, when you roll a natural even attack roll, you heal damage equal to your Strength modifier or your Wisdom modifier (double that modifier at 5th level; triple it at 8th level).
+
+##### Ki Power
+
+(_Imperial Phoenix Flare_): Once per day when you are staggered, you can spend 1 point of ki to heal using a recovery. You heal half the hit points you roll for the recovery, and one enemy engaged with you of your choice takes the other half in fire damage.
+
+###### Adventurer Feat
+
+You can now use this ki power twice per day.
+
+###### Champion Feat
+
+Once per day after rolling a death save, you can gain +4 bonus to the roll.
+
+###### Epic Feat
+
+The first time you die after taking this feat, you are resurrected at a place of power like your home monastery or other sanctum between one and four days later, assuming another resurrection doesn’t find you first. (This counts against your normal resurrection limit, as normal.)
+
+#### Spinning Willow Style
+
+When a ranged attack or close-quarters attack that targets AC hits you, you can roll a normal save. If you succeed, you take only half damage from the attack.
+
+##### Adventurer Feat
+
+You can now use Spinning Willow Style to save against ranged attacks and close-quarter attacks that target PD.
+
+##### Champion Feat
+
+If you roll a natural 18+ on the save, you instead take no damage from the attack and can choose one nearby enemy. It takes one-quarter of the damage as you deflect the attack.
+
+##### Epic Feat
+
+Spinning Willow Style saves are now easy saves (6+).
+
+##### Ki Power
+
+(_The Willow Bends)_: You can spend 1 point of ki to turn a failed Spinning Willow Style save into a success.
+
+### Champion Tier Talents
+
+At 6th level, you gain an additional monk class talent. You can choose to take another adventurer-tier talent, or select from the talents that follow.
+
+#### Disciple of the Hidden Flame
+
+When you gain this talent, choose a class: cleric, sorcerer, or wizard. Each time you take a full heal-up, choose a non-feature spell of your level or lower from that class. You can’t choose the same spell twice in a row; you must choose a different option each time you take a full heal-up.
+
+If the spell is at-will, you can cast it in place of a flow attack. If the spell is limited use, you can cast it in place of a finishing attacks. Use your Wisdom as the ability score that determines attack and damage with the spell.
+
+##### Ki Power
+
+(_Gather the Flame)_: You can spend 1 point of ki when you cast your Disciple of the Hidden Flame spell to cast it as if you possessed the adventurer-tier and champion-tier feat for that spell, if any. At 8th level, treat the spell like you possessed the epic-tier feat for it, if any, when you spend the ki.
+
+#### Improbable Stunt
+
+Once per battle as a quick action, you can pull off an outrageous improvisational stunt that no one else could manage, with the possible exception of a swashbuckling rogue! The stunt is not itself an attack but it might lead to one.
+
+The outrageous action of your stunt isn’t something you have to roll for, even if it would ordinarily require a skill check to pull off, though you’ll still have to roll for an attack that follows up your stunt.
+
+##### Ki Power
+
+(_Ludicrous Improbability Maneuver)_: You can spend 1 ki point to use Improbable Stunt again this battle.
+
+#### Path of the Perfect Warrior
+
+One battle per day, you can increase your JAB damage dice to d8s, your PUNCH damage dice to d10s, and your KICK damage dice to d12s.
+
+##### Ki Power
+
+(_Perfect Breath)_: Once per day when you are healing using a recovery, you can spend 1 point of ki to heal using a second recovery as well. The second recovery is a free.
+
+### Epic Tier Talents
+
+At 9th level, you gain an additional monk class talent. As usual, you can choose a talent from a lower tier, or an epic tier. Epic-tier talents have feats but no associated ki powers.
+
+#### Abundant Step
+
+Once per battle when the escalation die is 1+, you can teleport to a nearby location you can see as a move action.
+
+##### Epic Feat
+
+You can now teleport to a faraway location you can see.
+
+#### Champion of Three Worlds
+
+When you make a finishing attack, roll an additional d20 (usually two) for the attack roll. Use the result of your choice.
+
+##### Epic Feat
+
+Once per battle when you make a flow attack, you can roll an additional d20 for the attack roll.
+
+#### Procession of the Sun and Moon
+
+Once per level, while meditating during a quick rest, you can decide that it’s time for the start of a new day. You and each of your willing allies can make a hard save (16+). Each character who succeeds regains all spells, powers, hit points, ki, and recoveries as if they had taken a full heal-up and started a new day.
+
+The only character element that does not reset as if it was a new day are your icon relationship rolls and any icon relationships.
+
+##### Epic Feat
+
+You and each of your allies gain a bonus to the save equal to your Strength modifier or your Wisdom modifier.
+
+### Adventure Tier Forms
+
+#### Claws of the Panther
+
+##### Opening Attack (Panther Spins Free)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage, and you can pop free from the target.
+
+**Miss:** Damage equal to your level.
+
+##### Flow Attack (Cat Cuts between Hounds)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Natural Even Hit:** As a hit, plus each enemy engaged with you takes 1d6 damage (2d6 damage at 5th level; 4d6 damage at 8th level).
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** Damage equal to your level.
+
+##### Finishing Attack (Twinned Panther Claw)
+
+Melee attack
+
+**Targets:** Up to two enemies
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** Damage equal to your level.
+
+##### Adventurer Feat Ki Power
+
+_(Predator’s Return)_**:** You can spend 1 point of ki when your finishing attack misses all targets to use a flow attack instead of an opening attack with your next standard action—in effect, you get to skip the opening attack of your next form’s progression.
+
+#### Dance of the Mantis
+
+##### Opening Attack (Springing Mantis Strike)
+
+Melee attack
+
+**Special:** When you start your turn unengaged, you can move before the attack as part of the standard action for this attack.
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage.
+
+##### Flow Attack (The Pincer Whirls Shut)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage, or KICK + Strength damage against large or huge targets.
+
+**Natural Even Hit:** As a hit, plus you can roll a disengage check as a free action after the attack.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Precise Mantis Kick)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level + 2 vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Miss:** Your crit range with opening, flow, and finishing attacks expands by 1 until the end of the battle.
+
+**Natural Odd Miss:** Damage equal to your level.
+
+##### Adventurer Feat Ki Power
+
+_(The Dance Continues)_**:** You can spend 1 point of ki during your turn to roll a disengage check as free action.
+
+#### Dutiful Guardian
+
+##### Opening Attack (One Must Be Free)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage, and one ally engaged with the target can pop free from it.
+
+**Miss:** Damage equal to your level.
+
+##### Flow Attack (Wind Horse Shakes Mane)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage, and you choose one of the following benefits: you can take a move action as a free action; OR you gain a +4 bonus to PD until the start of your next turn.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Temple Lion Stands True)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus you can rally as a free action unless you have already rallied this battle.
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** Damage equal to your level.
+
+##### Adventurer Feat
+
+When you intercept an enemy that is moving to attack one of your allies, you gain a +3 bonus to all defenses until the end of that turn (so against that enemy’s attacks).
+
+#### Original Venom
+
+##### Opening Attack (First Deadly Venom)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage, and if the target is staggered after the attack, it also takes 5 ongoing poison damage.
+
+**Miss:** You take damage equal to your level.
+
+##### Flow Attack (Second Certain Toxin)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** PUNCH + Strength damage.
+
+**Natural Even Hit:** As a hit, plus 5 ongoing poison damage.
+
+**Miss:** You take damage equal to your level.
+
+##### Finishing Attack (Third Poisonous Lesson)
+
+Melee attack
+
+**Target:** One enemy taking ongoing damage
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus 10 ongoing poison damage, and if the target has 45 hp points or fewer, it’s hampered (save ends both). (The hp threshold also goes up automatically based on your level.)
+
+3rd level monk: 72 hp or fewer.
+
+5th level monk: 108 hp or fewer.
+
+7th level monk: 180 hp or fewer.
+
+9th level monk: 300 hp or fewer.
+
+**Natural Odd Hit:** As a hit, plus 5 ongoing poison damage.
+
+**Miss:** You take damage equal to your level.
+
+##### Adventurer Feat
+
+You gain _resist poison 14+._
+
+#### Three Cunning Tricksters
+
+##### Opening Attack (Fox Senses Weakness)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage.
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** —
+
+##### Flow Attack (Monkey Taps the Shoulder)
+
+Melee attack
+
+**Special:** When you use this attack, you can pop free from one enemy anytime during that turn as a free action.
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Crane Summons Carp)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus when an enemy engaged with you targets you with an attack before the start of your next turn, you can deal JAB + Strength damage to it as an interrupt action.
+
+**Miss:** Half damage.
+
+##### Adventurer Feat Ki Power
+
+_(The Gift Returns)_**:** When you roll a natural 18+ on a save, you can spend 1 point of ki to transfer the effect/ongoing damage you saved against to an enemy engaged with you (in addition to ending the effect on you). Of course, death saves and last gasp saves are excluded.
+
+#### Way of the Metallic Dragon
+
+##### Opening Attack (Bronze Thwarts an Army)
+
+Melee attack
+
+**Target:** One enemy
+
+**Special:** You must be engaged with two enemies to use this attack.
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Miss:** Damage equal to your level.
+
+##### Flow Attack (Silver Warrior Advances)
+
+Melee attack
+
+**Target:** One enemy that has more hit points than you
+
+**Attack:** Dexterity + Level vs. AC
+
+**Natural Even Hit:** PUNCH + Strength damage, and 10 ongoing cold damage.
+
+**Natural Odd Hit:** PUNCH + Strength damage, and one of your allies can pop free from the target.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (General Slays the Hordes)
+
+Melee attack
+
+**Targets:** Up to two enemies; choose one for the first attack and the other for the second attack
+
+**First Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Miss:** Damage equal to your level.
+
+**Second Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength fire damage.
+
+**Miss:** Damage equal to your level.
+
+##### Adventurer Feat Ki Power
+
+_(Become the Dragon)_**:** When you drop a non-mook enemy to 0 hp with a finishing attack, you can spend 1 point of ki to gain a second standard action during your _next_ turn. You’re gathering power, preparing to unleash havoc, or doing something similar. If for some reason you decide not to take the extra standard action during your next turn, you get the point of ki back, but can’t spend any more ki this battle.
+
+### Champion Tier Forms
+
+#### Heaven’s Thunder
+
+##### Opening Attack (Moon in Storming Sky)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** JAB + Strength damage, and each time an enemy attacks you before the start of your next turn, it takes thunder damage equal to twice your level after the attack.
+
+##### Flow Attack (Thunder Restores the Balance)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage, and you can roll a save against a save ends effect.
+
+**Natural Even Hit:** As a hit, plus you gain a bonus to the save equal to your Wisdom modifier.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (This Too Was Foreseen)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** KICK + Strength thunder damage.
+
+**Natural Even Hit:** As a hit, plus one random nearby enemy takes 10 ongoing thunder damage.
+
+**Natural Odd Hit:** As a hit, plus after this attack, your crit range expands by 1 until the end of the battle.
+
+**Miss:** Half damage.
+
+##### Champion Feat
+
+You can now target a nearby enemy with _this too was foreseen_.
+
+##### Epic Feat
+
+You now heal 5d10 hp each time you use a finishing attack while staggered.
+
+#### Iron Crusader Form
+
+##### Opening Attack (No Retreat)
+
+Melee attack
+
+**Special:** You can use this opening attack only if you or one of your allies has dropped to 0 hit points or below during this battle.
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Miss:** Half damage.
+
+##### Flow Attack (No Mercy)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+_Special:_ You gain a +4 bonus with this attack when you target a staggered enemy.
+
+**Hit:** PUNCH + Strength damage.
+
+**Miss:** Damage equal to your level.
+
+##### Finishing Attack (No Weakness)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+_Special:_ You gain a +4 bonus with this attack when you target an enemy taking ongoing damage.
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus you gain _resist damage 16+_ until the start of your next turn.
+
+**Miss:** Damage equal to your level.
+
+##### Champion Feat
+
+You can also use the _no retreat_ opening attack if you have been staggered this battle.
+
+##### Epic Feat
+
+One battle per day, your crit range expands by 2 (cumulative) each time you drop a non-mook enemy to 0 hp.
+
+  
+  
+
+#### Rising Phoenix
+
+##### Opening Attack (Rising Phoenix Fist)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** JAB + Strength fire damage.
+
+**Natural Even Miss:** 5 ongoing fire damage.
+
+**Natural Odd Miss:** —
+
+##### Flow Attack (Becomes the Pillar of Flame)
+
+Melee
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** PUNCH + Strength fire damage, and you can roll a disengage check as a free action. If you disengage from all enemies, you gain _flight_ until the end of your next turn.
+
+**Miss:** Damage equal to your level.
+
+##### Finishing Attack (Life Burning Fire Fist)
+
+Melee attack
+
+**Target:** One enemy that is higher level than you
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** PUNCH + Strength fire damage.
+
+**Natural Even Hit:** As a hit, plus you can heal using a recovery.
+
+**Natural Odd Hit:** As a hit, plus you can roll a save against a save ends effect.
+
+**Natural Even Miss:** Half damage.
+
+**Natural Odd Miss:** —
+
+##### Champion Feat
+
+Once per day as a free action, double the healing you get when you heal using a recovery (from any effect).
+
+##### Epic Feat
+
+One battle per day as a free action, choose yourself or a nearby ally. That creature gains a bonus to death saves equal to your Wisdom modifier until the end of the battle.
+
+#### Three Evil Dragons
+
+##### Opening Attack (The Burning Shadow)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage, and if the target is staggered after the attack, choose one: you can pop free from the target; OR the target takes ongoing acid damage equal to your level.
+
+**Miss:** Damage equal to your level.
+
+##### Flow Attack (Blue Lightning Fist)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Natural Even Hit:** PUNCH + Strength damage, and one random nearby enemy takes lightning damage equal to double your level.
+
+**Natural Odd Hit:** PUNCH + Strength damage, and you gain _flight_ until the end of your next turn.
+
+**Miss:** Half damage, and one random nearby enemy takes lightning damage equal to your level.
+
+##### Finishing Attack (Red Fury)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage, and 1d6 extra fire damage for each point on the escalation die.
+
+**Miss:** Damage equal to your level.
+
+##### Champion Feat
+
+Once per battle when an enemy hits you with an attack that targets AC or PD while you are flying, you can force that enemy to reroll the attack as a free action.
+
+##### Epic Feat
+
+Once per day when you miss all targets with a finishing attack, you can make another finishing attack with your next standard action—in effect, you get to redo the last form of that progression.
+
+#### Tiger in Storm
+
+##### Opening Attack (Stalking Tiger)
+
+Melee attack
+
+**Target:** One enemy that isn’t engaged with any of your allies.
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage.
+
+**Natural Even Hit:** As a hit, plus 2d6 ongoing lightning damage.
+
+**Miss:** Both you and the target take damage equal to your level.
+
+##### Flow Attack (Tiger Follows Blood)
+
+Melee attack
+
+**Target:** One enemy that isn’t engaged with any of your allies.
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage, and you can pop free from the target.
+
+**Natural Even Hit:** As a hit, plus if you are engaged with an enemy other than the target at the _end_ of your turn, one enemy engaged with you takes 10 damage (as your attack sets up a final clawing strike).
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Striped Lightning Roars)
+
+Melee attack
+
+**Target:** One enemy that isn’t engaged with any of your allies.
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus 1d3 nearby enemies other than the target each take lightning damage equal to double your level.
+
+**Miss:** Half damage.
+
+##### Champion Feat Ki Power
+
+_(Storm’s Eye)_**:** When an enemy misses you with an attack that deals cold, lightning, or thunder damage, you can spend 1 point of ki to heal using a recovery.
+
+##### Epic Feat
+
+You gain _resist energy damage 16+_ to cold, thunder, and lightning.
+
+### Epic Tier Forms
+
+#### Death’s Quivering Shadow
+
+##### Opening Attack (Invoke the Name)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** JAB + Strength damage.
+
+**Natural Even Hit:** As a hit, plus the target takes ongoing negative energy damage equal to its level.
+
+**Miss:** You take 5 ongoing negative energy damage.
+
+##### Flow Attack (Stunning Fist)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Natural Even Hit:** As a hit, plus if the target has 180 hp or fewer after the attack, it’s stunned until the end of your next turn.
+
+**Miss:** Damage equal to your level.
+
+##### Finishing Attack (Ghostwalk of the Fallen King)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage, and 15 ongoing negative energy damage.
+
+**Natural Even Hit:** As a hit, plus until the end of your next turn, you gain _flight_ and _resist damage 16+_ to all damage as you become incorporeal. (You can move through solid objects but can’t end your turn in them.)
+
+**Miss:** Damage equal to your level.
+
+##### Epic Feat Ki Power
+
+_(Quivering Palm)__**:**_ Once per day when you hit a target with a finishing attack, you can spend 1 point of ki to create a link with the target. Until the next full heal-up, regardless of how faraway the target is, you can spend 1 point of ki and two consecutive quick actions to deal PUNCH + Wisdom damage to the target. You can keep spending quick actions and ki to deal this damage once per round until you run out of ki for the day.
+
+#### Feathered Serpent
+
+##### Opening Attack (Coils Dispense Blessings)
+
+Melee attack
+
+**Target:** Each enemy engaged with you
+
+**Attack:** Wisdom + Level vs. AC
+
+**Hit:** JAB + Wisdom damage.
+
+**Miss:** Damage equal to your level.
+
+##### Flow Attack (Feathers on Talons on Scales)
+
+Melee attack
+
+**Always:** When you use this flow attack, choose one effect: pop free from one enemy anytime during your turn as a free action; or you gain _flight_ until the end of your next turn.
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Poisoned Heaven Kick)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage.
+
+**Natural Even Hit:** As a hit, plus if the target has 180 hp or fewer after the attack, it’s hampered until the end of your next turn. If it has more than 180 hp, it takes 20 ongoing poison damage instead.
+
+**Miss:** Half damage.
+
+##### Epic Feat
+
+Once per battle as a quick action, you can roll a difficult save (16+) against a save ends effect affecting you that was caused by an enemy’s attack. If you succeed, transfer the effect to an enemy engaged with you.
+
+#### Flagrant Blossoms
+
+##### Opening Attack (The Petals Open)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage, and if this attack drops a non-mook to 0 hp, you can use a finishing attack with your next standard action.
+
+##### Flow Attack (Fist Shows the Path to Wisdom)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Natural Even Hit:** As a hit, plus a random nearby ally can roll an icon relationship die (you choose which icon) that can be used as a story-guide result later in the adventure; the roll must be a 5 or a 6 to get an advantage as normal.
+
+**Miss:** Half damage.
+
+##### Finishing Attack (Lotus Dreams the World)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Wisdom + Level vs. MD
+
+**Natural Even Hit:** KICK + Wisdom damage, and you or an ally gains a +2 bonus to saves until the end of the battle.
+
+**Natural Odd Hit:** KICK + Wisdom damage, and the target takes a –2 penalty to saves until the end of the battle.
+
+**Miss:** Half damage.
+
+##### Epic Feat
+
+Once per day when you use the _lotus dreams the world_ finishing attack, a nearby ally can heal using a free recovery and can roll a save against each save ends effect affecting it.
+
+#### Spiral Path
+
+##### Opening Attack (The Cycle Opens)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** JAB + Strength damage.
+
+**Natural Even Hit:** As a hit, plus a different nearby enemy takes force damage equal to half that damage.
+
+##### Flow Attack (Spiral Ascension Widens)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** PUNCH + Strength damage.
+
+**Natural Even Hit:** As a hit, plus the escalation die increases by 1.
+
+**Miss:** Damage equal to your level.
+
+##### Finishing Attack (Star Joins as Ally)
+
+Melee attack
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** KICK + Strength damage, and as a free action you can teleport next to a different nearby enemy you can see (engaging it) and make a PUNCH attack against it.
+
+_Miss (PUNCH):_ The target takes damage equal to your level.
+
+**Miss:** Half damage, and you can’t use attacks from the Spiral Path form until your next battle.
+
+##### Epic Feat
+
+One battle per day, choose a monk talent you don’t ordinarily possess. This battle, you have that talent.

--- a/Classes/Necromancer.md
+++ b/Classes/Necromancer.md
@@ -1,0 +1,1231 @@
+---
+aliases: [Necromancer]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Necromancer]
+updated:: 2023-05-07
+---
+
+# Ability Scores
+
+Necromancers gain a +2 class bonus to Intelligence or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+# Backgrounds
+
+Possible backgrounds include: failed village priest, archeologist, swamp baron, living dungeon escapee, former necromancer acolyte, death giant servitor, former mummy, reformed outlaw, resurrected Imperial hero, and burnt-out wizard.
+
+# Gear
+
+At 1st level, a necromancer starts with various dark robes or traveling clothes, a dagger, a staff, a few treasured bones or funerary urns, and other miscellaneous items suggested by their backgrounds.
+
+## Gold Pieces
+
+Necromancers may start with either 25 gp or 1d6 x 10 gp.
+
+## Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 10      | —           |
+| Heavy      | 11      | -2          |
+| Shield     | 1       | -2          |
+
+## Melee Weapons
+
+|                  | One-Handed                        | Two-Handed               |
+| ---------------- | --------------------------------- | ------------------------ |
+| Small            | 1d4 dagger                        | 1d6 club, staff          |
+| Light or Simple  | 1d6 (-2 atk) mace, shortsword     | 1d8 (-4 atk) spear       |
+| Heavy or Martial | 1d8 (-5 atk) longsword, warhammer | 1d10 (-6 atk) greatsword |
+
+## Ranged Weapons
+
+|                  | Thrown               | Crossbow                    | Bow                   |
+| ---------------- | -------------------- | --------------------------- | --------------------- |
+| Small            | 1d4 dagger, star     | 1d4 hand crossbow           | —                     |
+| Light or Simple  | 1d6 (-2 atk) javelin | 1d6 (-1 atk) light crossbow | 1d6 (-2 atk) shortbow |
+| Heavy or Martial | —                    | 1d8 (-4 atk) heavy crossbow | 1d8 (-5 atk) longbow  |
+
+# Level Progression
+
+| Necromancer        | Total Hit Points           | Total Feats                    | 1st level (M) | 3rd level (M) | 5th level (M) | 7th level (M) | 9th level (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|---------------|---------------|---------------|---------------|---------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | 3             | —             | —             | —             | —             | Not affected             | ability modifier                |
+| Level 1            | (6 + CON mod*) x 3         | 1 adventurer                   | 4             | —             | —             | —             | —             |                          | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 5             | —             | —             | —             | —             |                          | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 3             | 3             | —             | —             | —             |                          | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | —             | 6             | —             | —             | —             | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer  champion         | —             | 3             | 4             | —             | —             |                          | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | —             | —             | 7             | —             | —             |                          | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | —             | —             | 3             | 5             | —             | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | —             | —             | —             | 8             | —             |                          | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | —             | —             | —             | 3             | 6             |                          | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | —             | —             | —             | —             | 9             | +1 to 3 abilities        | 3 x ability modifier            |
+
+Although not listed on the table, this class gets three talents. It does not get more at higher levels.
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+*You don’t subtract the modifier from your base hp value if you have a negative Constitution modifier.
+
+# Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus             | +2 Intelligence or Charisma (different from racial bonus)    |
+|---------------------------|--------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                              |
+| Armor Class (light armor) | 10 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense          | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense            | 11 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                | (6 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                | 8                                                            |
+| Recovery Dice             | (1d6 x Level) + Con mod                                      |
+| Backgrounds               | 8 points, max 5 in any one background                        |
+| Icon Relationships        | 3 points (4 at 5th level; 5 at 8th level)                    |
+| Talents                   | 3                                                            |
+| Feats                     | 1 per Level                                                  |
+| Feats                     | 1 per Level                                                  |
+| Ability Bonus             | +2 Strength or Constitution (different from racial bonus)    |
+
+  
+
+# Basic Attacks
+
+## Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** —
+
+## Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+# Class Features
+
+All necromancers share the following class features.
+
+## Arcane Implements
+
+As a character casting arcane magic, your best options for improving your spellcasting are wands and staffs.
+
+## Death’s Master
+
+All necromancers must spend at least one relationship point with any necromantic icon. (This may be conflicted or negative.) If your one unique thing somehow suggests that you might be free of this requirement, make a case to your GM that this is a way in which you are unique.
+
+## Ritual Magic
+
+Necromancers can cast their spells as rituals (see Running the Game, Rituals).
+
+## Spell Choices
+
+Like other standard spellcasters, you choose the spells you will be able to cast after each full heal-up.
+
+## Summoning
+
+Your summoning spells use the standard summoning rules. The following feats enable you to improve your summoning powers.
+
+### Adventurer Feat
+
+Your summoned creatures can add the escalation die to their attacks.
+
+### Champion Feat
+
+When you summon mooks, increase the number of mooks you summon by 1.
+
+### Epic Feat
+
+The first time one of your non-mook summoned creatures is dropped each battle, roll a normal save. If you succeed, the summoned creature is not slain but instead remains in the battle with 10 hp.
+
+## Wasting Away
+
+Necromancers are frail, gaunt, parched, skinny, sickly, wasted, cadaverous, dependent on unearthly substances, or partially dead. This isn’t just an aesthetic note—as a necromancer, you must subtract your Constitution modifier from all your necromancer spell attacks if your modifier is positive. In addition, you don’t die until you fail five death saves. Similarly, you don’t succumb to last gasp save effects until you fail the fifth save.
+
+### Adventurer Feat
+
+If your Constitution modifier is negative, add +1 to your necromancer spell attacks.
+
+### Champion Feat
+
+You don’t die from damage until your negative hit points equal your maximum hit points, instead of half your maximum.
+
+### Epic Feat
+
+One battle per day, you can choose to succeed with death saves on an 11+ instead of a 16+.
+
+# Class Talents
+
+## Cackling Soliloquist
+
+If you spend your move action, your quick action, _and_ your standard action casting a daily spell that ordinarily only requires a standard action—while screaming grandiloquently, cackling maniacally, or megalomaniacally describing the grandeur of your plans and the futility of your enemies’ resistance—the daily spell is recharge 18+ after battle instead of daily, and you can invent a slight improvement to the spell, especially if it’s partly story-oriented, that provides an extra benefit determined by the GM or by you (with GM approval).
+
+### Adventurer Feat
+
+You gain temporary hit points equal to 1d6 + your level + Charisma modifier when you use Cackling Soliloquist (double your Charisma modifier at 5th level; triple it at 8th level).
+
+### Champion Feat
+
+Your soliloquized spell is now a recharge 16+ after battle instead of 18+.
+
+### Epic Feat
+
+Once per day, you can hog the spotlight when using Cackling Soliloquist. When you do, you heal using a free recovery and steal the escalation die, keeping it all to yourself. Until the end of your next turn, you are the only creature—PC, NPC, or monster—that can use the escalation die, _and_ you treat the escalation die as if it were an 8. At the end of your next turn, return the escalation die to the table, one point higher than it was when you seized it.
+
+## Dead Wizard
+
+You gain the Cantrips class feature from the wizard class. The talent functions like the wizard’s class feature with the following exceptions:
+
+-   You can’t cast _mending_.
+    
+-   Your _light_ cantrip has a sickly flicker or a dark edge. Feel free to call it _darklight_.
+    
+
+### Adventurer Feat
+
+You can take a wizard spell in place of one of your necromancer spells of the same level. You can change this spell for a new one you know whenever you take a full heal-up.
+
+### Champion Feat
+
+You gain a bonus wizard spell that is at least two levels below your level_**,**_ in addition to the spells you can cast as a necromancer. You can change this spell for a new one you know whenever you take a full heal-up.
+
+### Epic Feat
+
+You gain a second bonus wizard spell, but this one can be of your level or lower. You can change this spell for a new one you know whenever you take a full heal-up.
+
+## Death Priest
+
+When you have icon relationship advantages you’re waiting to use during a session, you can interpret them as interactions/public discussions with the spirits of the recent or ancient dead in the area, providing information you require (and possibly, when there’s a complication from a 5 roll, also providing that information to your enemies or otherwise getting you into some type of trouble).
+
+_**Séance:**_ Similarly, once per day while you’re not in battle, you can perform a short rite (1–2 minutes) to call upon a spirit of the dead that’s related to a random icon other than a necromantic icon. The spirit will speak to you, relaying information helpfully, or under protest if it’s related to an icon that considers you an enemy or with which you have a negative relationship.
+
+You can’t always rely on the dead to speak the truth, or to know what they are talking about. Whenever you use the séance power above, the GM secretly rolls a d20 before the discussion. On a 3+, the spirit knows what it is talking about. On a 1–2, the information is outdated, sabotaged, or just erroneous. (Note that this roll is only used for séances, not for spirits you talk to thanks to icon advantages mentioned above.)
+
+At 5th level you can use séance two times per day. At 8th level you can use it three times per day.
+
+### Adventurer Feat
+
+Whenever you take a full heal-up, you can choose whether you’d like to move a single point in a relationship with a positively or negatively aligned icon to one of the other icons. Tell a story of what has taken place to cause the shift, unless it’s already obvious from the events of the campaign. When you shift this relationship, the new point must match any current relationships with that icon, but it can be positive, negative, or conflicted if it’s currently the only point you have with that icon.
+
+### Champion Feat
+
+You gain a bonus cleric spell that is at least two levels below your level, in addition to the spells you can cast as a necromancer. You can change this spell for a new one you know whenever you take a full heal-up. You can also substitute references to Wisdom with references to Intelligence in the spell.
+
+### Epic Feat
+
+You gain the lowest-tier feat, if any, associated with your bonus cleric spell.
+
+## Deathknell
+
+As a quick action, you can drop a nearby enemy that has 5 hp or fewer down to 0 hp. When you drop an enemy using Deathknell, you heal 1d6 hit points.
+
+You can use Deathknell to drop a mook, but only if it’s the last mook in its mob and the mob has 5 hp or fewer left.
+
+3rd level spell: Drop an enemy with 10 hp or fewer. Heal 1d10 hit points.
+
+5th level spell: Drop an enemy with 15 hp or fewer. Heal 2d8 hit points.
+
+7th level spell: Drop an enemy with 20 hp or fewer. Heal 4d6 hit points.
+
+9th level spell: Drop an enemy with 25 hp or fewer. Heal 4d8 hit points.
+
+### Adventurer Feat
+
+When you use Deathknell, one of your nearby conscious allies can gain the healing instead of you.
+
+### Champion Feat
+
+Double the healing gained from Deathknell when you drop an enemy.
+
+### Epic Feat
+
+You can increase the escalation die by 1 instead of healing when you kill a non-mook enemy with Deathknell.
+
+## It’s Complicated
+
+When you roll icon relationship dice, the first 6 you roll is a 5 instead.
+
+You gain an extra necromancer spell at the highest spell level you can normally cast (as shown under spells known on the necromancer level progression chart). For example, you would gain an extra 3rd level spell if you’re 4th level, or an extra 5th level spell if you’re 5th level.
+
+### Champion Feat
+
+All 6s you roll with relationship dice count as 5s. You gain another extra necromancer spell, but it must be at least two levels lower than your level.
+
+## Redeemer
+
+Undead you summon release holy energy bursts as they drop to 0 hp, dealing a small amount of damage to each enemy engaged with them.
+
+Mooks you summon deal holy damage equal to your Charisma modifier (double your Charisma modifier at 5th level; triple it at 8th level).
+
+Non-mooks you summon deal holy damage equal to your Charisma modifier x 1d4 (1d8 at 5th level; 2d6 at 8th level).
+
+In story terms, you’re not likely to have a positive relationship with any necromantic icons if you take the Redeemer talent.
+
+### Adventurer Feat
+
+The first time each battle an undead creature you have summoned attacks, it gains an attack bonus equal to your Charisma modifier.
+
+### Champion Feat
+
+When one of your summoned undead creatures drops to 0 hp, instead of having it deal holy damage to engaged enemies, you can heal hit points equal to that damage instead.
+
+### Epic Feat
+
+You can memorize a single spell that summons undead twice.
+
+## Skeletal Minion
+
+You have a skeleton minion the same level as you that acts as a servant, fights alongside you in battle, and is replaced by a new skeletal minion when it inevitably collapses or is destroyed. It is not a summoned create; summoning rules don’t ap\ply.
+
+Your minion acts on your initiative, taking a standard action, a move action, and (if applicable) a quick action. You decide whether it takes its turn before or after you.
+
+The listed attack and damage values are for melee attacks. Your skeletal minion can’t heal. When it drops to 0 hp, it’s destroyed for that battle. When you take a quick rest, a new (or patched up) skeletal minion will take its place.
+
+### Level 1 Skeletal Minion
+
+**Attack** +6 vs. AC
+
+**Damage** d6
+
+**AC** 17
+
+**PD** 15
+
+**MD** 11
+
+**HP** 14
+
+### Level 2 Skeletal Minion
+
+**Attack** +7 vs. AC
+
+**Damage** d8
+
+**AC** 18
+
+**PD** 16
+
+**MD** 12
+
+**HP** 18
+
+### Level 3 Skeletal Minion
+
+**Attack** +9 vs. AC
+
+**Damage** d12
+
+**AC** 19
+
+**PD** 17
+
+**MD** 13
+
+**HP** 22
+
+### Level 4 Skeletal Minion
+
+**Attack** +10 vs. AC
+
+**Damage** 2d6
+
+**AC** 21
+
+**PD** 19
+
+**MD** 15
+
+**HP** 27
+
+### Level 5 Skeletal Minion
+
+**Attack** +11 vs. AC
+
+**Damage** 2d8
+
+**AC** 22
+
+**PD** 20
+
+**MD** 16
+
+**HP** 36
+
+### Level 6 Skeletal Minion
+
+**Attack** +13 vs. AC
+
+**Damage** 3d6
+
+**AC** 23
+
+**PD** 21
+
+**MD** 17
+
+**HP** 45
+
+### Level 7 Skeletal Minion
+
+**Attack** +14 vs. AC
+
+**Damage** 3d8
+
+**AC** 25
+
+**PD** 23
+
+**MD** 19
+
+**HP** 54
+
+### Level 8 Skeletal Minion
+
+**Attack** +15 vs. AC
+
+**Damage** 4d6
+
+**AC** 26
+
+**PD** 24
+
+**MD** 20
+
+**HP** 72
+
+### Level 9 Skeletal Minion
+
+**Attack** +17 vs. AC
+
+**Damage** 4d8
+
+**AC** 27
+
+**PD** 25
+
+**MD** 21
+
+**HP** 90
+
+### Level 10 Skeletal Minion
+
+**Attack** +18 vs. AC
+
+**Damage** 5d6
+
+**AC** 28
+
+**PD** 26
+
+**MD** 22
+
+**HP** 108
+
+### Skeletal Minion Feats
+
+Like animal companion feats, skeletal minion feats don’t build on each other. You don’t have to take them in a particular order, as long as you qualify for the tier.
+
+#### Adventurer Feats
+
+-   Your skeletal minion now adds the escalation die to its attack rolls_**.**_
+    
+-   When an enemy attempts to disengage from the skeletal minion, it takes a penalty to the check equal to the escalation die.
+    
+-   As a quick action, you can set your skeletal minion ablaze, or extinguish the blaze. While it’s flaming, your skeleton minion’s damage dice increase by one size, and it deals fire damage with its melee attacks, but it takes damage equal to your level each time its natural attack roll is odd.
+    
+
+#### Champion Feats
+
+-   Add a damage die of the same size to your skeletal minion’s damage rolls (for example, 3d6 becomes 4d6).
+    
+-   Add double your Charisma modifier to your skeletal minion’s hit points. At 8th level, add triple it.
+    
+-   Add a damage die of the same size to your skeletal minion’s damage rolls (for example, 4d6 becomes 5d6, and this is cumulative with the champion feat).
+    
+
+#### Epic Feats
+
+-   Your skeletal minion gains a +2 bonus to all defenses.
+    
+
+## Sorta Dead
+
+In some ways, you’re dead already. You don’t need to eat or sleep or breathe. You can’t drown in normal water/liquid, though magical gas will still affect you.
+
+When a spell or effect targets or applies to undead, you can decide whether you want to count as undead for that specific effect. (For example, you could count as undead to take advantage of a target’s vulnerability created by the _ripping claws_ attack of a starving ghoul mook you summoned via _summon undead_.)
+
+The first time you die each level, roll a normal save, adding your Charisma modifier. If you succeed, you heal using a free recovery instead of dying. If you were dying because of last gasp saves, consider yourself saved from the last gasp problem also.
+
+### Adventurer Feat
+
+You gain _resist poison 16+_ and _resist negative energy 16+_.
+
+### Champion Feat
+
+The spells _zombie form_, _ghoul form_, _ghost form_, and _vampiric form_ all function as recharge 16+ after battle spells for you, though you still memorize them as daily spells.
+
+### Epic Feat
+
+No undead creature that is not under the direct command of a necromantic icon can attack you unless you attack it or cast a spell against it first.
+
+# 1st Level Spells
+
+## Channel Life
+
+Ranged spell
+
+Once per battle
+
+**Attack Target:** One _random_ nearby creature other than the healing target
+
+**Healing Target:** One nearby ally
+
+**Attack:** Intelligence + Level vs. MD (make one attack only against the attack target)
+
+**Hit vs. an enemy:** 2d6 + Intelligence negative energy damage, and the healing target can heal using a recovery.
+
+**Hit vs. an ally:** 5 negative energy damage, and the healing target can heal using a recovery.
+
+**Miss:** The spell is not expended.
+
+3rd level spell: 5d6 damage vs. enemy, 10 damage vs. ally.
+
+5th level spell: 5d10 damage vs. enemy, 15 damage vs. ally.
+
+7th level spell: 7d10 damage vs. enemy, 20 damage vs. ally.
+
+9th level spell: 10d12 damage vs. enemy, 30 damage vs. ally.
+
+### Adventurer Feat
+
+You can now cast this spell twice per battle.
+
+### Champion Feat
+
+Staggered allies can no longer be an attack target of the spell.
+
+### Epic Feat
+
+On a miss, the spell now deals half damage to the target, but there is still no effect on the healing target.
+
+## Chant of Endings
+
+Ranged spell
+
+At-Will
+
+**Target:** The nearby enemy with the fewest hit points (you choose if there’s a tie; you also don’t have to be able to see that enemy)
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 1d10 + Intelligence negative energy damage.
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 8d10 damage.
+
+### Adventurer Feat
+
+You can now choose whether or not you want to ignore mooks as targets when you cast the spell.
+
+### Champion Feat
+
+Misses now deal damage equal to your level.
+
+### Epic Feat
+
+While the escalation die is 4+, you can now target two nearby enemies with the fewest hit points with this spell.
+
+## Command Undead
+
+Ranged spell
+
+Once per battle
+
+**Target:** One nearby undead creature with 64 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target is confused (hard save ends, 16+).
+
+3rd level spell: Target with 96 hp or fewer.
+
+5th level spell: Target with 160 hp or fewer.
+
+7th level spell: Target with 266 hp or fewer.
+
+9th level spell: Target with 460 hp or fewer.
+
+### Adventurer Feat
+
+A miss doesn’t expend the spell.
+
+### Champion Feat
+
+If you wish, the target doesn’t make any attacks while confused. Instead it becomes compliant, answers short questions if possible, and follows other suggestions that don’t lead directly to damaging itself or other creatures. Basically, while confused it becomes a slightly puzzled friend, which may wonder why your other friends are hurting it while it’s trying to be helpful.
+
+_**Epic Feat**_
+
+The target now adds the escalation die to its attacks while confused by this spell_._
+
+## Death’s Gauntlet
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby creature
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 1d4 + Intelligence modifier ongoing negative energy damage.
+
+_Special:_ Instead of taking the ongoing damage at the end of its turn, the target can use its standard action to strike out at the skeletal limbs or spectral arms that are flailing at it. When it does, the ongoing damage ends and you can’t use _death’s gauntlet_ again until the end of your next turn.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 2d8 damage.
+
+5th level spell: 4d6 damage.
+
+7th level spell: 6d6 damage.
+
+9th level spell: 7d10 damage.
+
+### Adventurer Feat
+
+When a target uses a standard action to end _death’s gauntlet_ ongoing damage, it takes negative energy damage equal to your level.
+
+### Champion Feat
+
+When you roll a natural even hit against a target with this spell, the ongoing negative energy damage has a hard save (16+).
+
+### Epic Feat
+
+The spell can also target MD instead of PD.
+
+## Summon Undead (1st level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a mob of 1d3 + 1 crumbling skeleton mooks, as per the summoning rules. These skeletons fight for you until the end of the battle or until they drop to 0 hp, whichever comes first.
+
+As you cast the spell at higher levels, the mooks you summon vary, as shown below. The stats for each mob of mooks you can summon are also shown below.
+
+3rd level spell: 1d3 + 1 putrid zombie mooks.
+
+5th level spell: 1d3 + 1 starving ghoul mooks.
+
+7th level spell: 1d3 + 1 masterless vampire spawn mooks.
+
+9th level spell: 1d3 + 1 Blackamber skeletal warrior mooks.
+
+### Champion Feat
+
+You now summon 1d4 + 1 mooks when you cast this spell instead of 1d3 + 1.
+
+### Epic Feat
+
+If one or more mooks summoned by the spell survive the battle, you can keep one mook with you until the next battle. Or until someone in the party or the world gets sick of it and slays the thing.
+
+### Crumbling Skeleton
+
+| Normal 1st level Mook Undead  | Initiative: +6 Vulnerability: holy  Sword +6 vs. AC—3 damage  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 16 14 10 6 |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|------------|
+
+### Putrid Zombie
+
+| Normal 3rd level Mook Undead  | Initiative: +2 Vulnerability: holy  Rotting fist +7 vs. AC—5 damage Natural 16+: Both the zombie and its target take 1d6 damage!  Headshot: A critical hit against a putrid zombie deals triple damage instead of the normal double damage for a crit. | AC PD MD HP | 18 16 12 16 |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Starving Ghoul
+
+| Normal 5th level Mook Undead  | Initiative: +8 Vulnerability: holy  Ripping claws +10 vs. AC—7 damage Natural 16+ The target is vulnerable (attacks vs. it have crit range expanded by 2) to attacks by undead until the end of the ghoul’s next turn.  Pound of flesh: The starving ghoul’s ripping claws attack deals +5 damage against vulnerable targets. | AC PD MD HP | 20 18 14 18 |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+
+### Masterless Vampire Spawn
+
+| Normal 7th level Mook Undead  | Initiative: +11 Vulnerability: holy  Claw +11 vs. AC—14 damage Natural even hit: The vampire spawn can make a fangs attack against the target as a free action.  [Special trigger] Fangs +15 vs. AC—7 damage, and a humanoid target is weakened (–4 attack and defenses) until the end of the masterless vampire spawn’s next turn | AC PD MD HP | 22 19 17 24 |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+
+### Blackamber Skeletal Warrior
+
+| Normal 9th level Mook Undead  | Initiative: +15 Vulnerability: holy  Shortsword +15 vs. AC—28 damage Natural 16+: Each Blackamber skeletal warrior in the battle moves up 1d4 points in initiative order. Natural even miss: 10 damage.  R: Javelin +13 vs. AC—24 damage  Press advantage: The warrior deals +1d10 damage with its attacks against enemies that have a lower initiative than it.  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 26 20 22 25 |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+## Terror
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby creature with 50 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target uses all its actions during its turn to move away from the battle, disengaging from enemies to do so (hard save ends, 16+). If it fails to disengage with all of its actions, it won’t take opportunity attacks by moving. The effect also ends when you or one of your allies attacks the target.
+
+**Miss:** 1d10 + Intelligence psychic damage.
+
+3rd level spell: Target with 70 hp or fewer, 4d6 damage on a miss.
+
+5th level spell: Target with 100 hp or fewer, 6d6 damage on a miss.
+
+7th level spell: Target with 180 hp or fewer, 6d10 damage on a miss.
+
+9th level spell: Target with 300 hp or fewer, 8d10 damage on a miss.
+
+### Adventurer Feat
+
+When you miss with this spell, you regain it after the battle.
+
+### Champion Feat
+
+Increase the hit point threshold of targets by 50 hp.
+
+### Epic Feat
+
+The target also takes the miss damage each time it fails a save against the effect.
+
+## Unholy Blast
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d6 + Intelligence negative energy damage.
+
+**First Miss:** Half damage, and make the attack again against an enemy you haven’t already targeted with _unholy blast_ this turn.
+
+**Second Miss:** Half damage, or full damage if the escalation die is 1+ and you choose to decrease it by 1.
+
+3rd level spell: 4d10 damage.
+
+5th level spell: 7d10 damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+### Adventurer Feat
+
+The spell can now target faraway enemies.
+
+### Champion Feat
+
+The spell’s damage dice increase to d12s.
+
+### Epic Feat
+
+The spell now targets two nearby enemies, but you can’t attack the same target twice as you work through the misses and hits.
+
+## Zombie Form
+
+Ranged spell
+
+Daily
+
+**Special:** You can only cast this spell outside of battle; it requires 2d4 rounds to cast.
+
+**Target:** You or one willing nearby ally
+
+**Effect:** The target gains 30 temporary hit points that last until the end of the next battle. Until the end of the next battle, the target takes a –5 penalty to Charisma and Dexterity skill checks (no penalty to attacks), to disengage checks, and to initiative rolls.
+
+3rd level spell: 50 temporary hit points.
+
+5th level spell: 80 temporary hit points.
+
+7th level spell: 130 temporary hit points.
+
+9th level spell: 210 temporary hit points.
+
+# 3rd Level Spells
+
+## The Bones Beneath
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby mook (and hence, its mob)
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d12 + Intelligence negative energy damage, and each mook in the mob that drops becomes a skeleton mook under your control until the end of the battle.
+
+**Miss:** Half damage, and each mook in the mob that drops becomes a skeleton mook under your control until the end of the battle.
+
+5th level spell: 7d12 damage.
+
+7th level spell: 2d6 x 10 damage.
+
+9th level spell: 2d10 x 10 damage.
+
+**Special:** The stats for the mooks created by each level of _the bones beneath_ appear below. The level or physical nature of the mooks is irrelevant; the magic of the spell turns whatever creatures it’s forced to work with into skeletal mook allies with the stats below.
+
+The new mooks take their turn immediately after your turn.
+
+This isn’t a summoning spell, so the mooks created by this spell don’t count as summoned mooks.
+
+### Just-ripped-free Skeleton Mook (3rd)
+
+| Normal 3rd level Mook Undead  | Initiative: +8 Vulnerability: holy  Sword or axe or whatever +8 vs. AC—5 damage  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 18 16 12 11 |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Just-ripped-free Skeleton Mook (5th)
+
+| Normal 3rd level Mook Undead  | Initiative: +10 Vulnerability: holy  Sword or axe or whatever +10 vs. AC—8 damage  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 20 18 14 18 |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Just-ripped-free Skeleton Mook (7th)
+
+| Normal 3rd level Mook Undead  | Initiative: +12 Vulnerability: holy  Sword or axe or whatever +12 vs. AC—16 damage  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 22 20 16 27 |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Just-ripped-free Skeleton Mook (9th)
+
+| Normal 3rd level Mook Undead  | Initiative: +14 Vulnerability: holy  Sword or axe or whatever +14 vs. AC—28 damage  Resist weapons 16+: When a weapon attack targets this creature, the attacker must roll a natural 16+ on the attack roll or it only deals half damage. | AC PD MD HP | 24 22 18 44 |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+## Circle of Death
+
+Ranged spell
+
+Daily
+
+**Special:** You can’t cast this spell unless the escalation die is 3+.
+
+**Target:** Each nearby creature (allies and enemies)
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit vs. an enemy:** 5d12 + Intelligence negative energy damage.
+
+**Hit vs.** **an ally:** 1d6 negative energy damage.
+
+**Miss vs. an enemy:** Half damage.
+
+**Miss vs.** **an ally:** You take half the damage the ally would have taken on a hit.
+
+5th level spell: 8d12 damage to an enemy, 2d6 damage to an ally.
+
+7th level spell: 2d8 x 10 damage to an enemy, 3d8 damage to an ally.
+
+9th level spell: 4d6 x 10 damage to an enemy, 3d10 damage to an ally.
+
+## Ghoul Form
+
+Ranged spell
+
+Daily
+
+**Target:** You or one willing nearby ally
+
+**Effect:** Until the end of the battle, the target gains a +4 melee attack bonus. In addition, enemies engaged with the target are vulnerable to its melee attacks.
+
+The target also only gains half the normal amount from healing effects, no matter the source.
+
+5th level spell: The target now also gains a +4 bonus to initiative, Dexterity checks, and disengage checks.
+
+7th level spell: Enemies engaged with the target are now vulnerable to all attacks.
+
+9th level spell: The target also rolls an icon relationship die with any necromantic icon, choosing whether the relationship is positive or negative.
+
+## Negative Energy Shield
+
+Close-quarters spell
+
+Daily
+
+**Target:** You
+
+**Effect:** Until the end of the battle, when an enemy engaged with you attacks you with a natural odd attack roll, it takes 6d6 + Intelligence negative energy damage.
+
+5th level spell: 6d10 damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+## Ray of Enfeeblement
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy with 96 hp or fewer
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d12 + Intelligence negative energy damage, and the target is weakened (save ends)
+
+**Miss:** Half damage.
+
+5th level spell: 7d12 damage.
+
+7th level spell: 2d6 x 10 damage.
+
+9th level spell: 2d10 x 10 damage.
+
+### Adventurer Feat
+
+The spell can now target an enemy with any number of hit points while the escalation die is 3+.
+
+### Champion Feat
+
+The save against weakened is now a hard save (16+).
+
+### Epic Feat
+
+On a miss, the target is also dazed (save ends).
+
+## Speak with Dead
+
+Ranged spell
+
+Variable
+
+_Special:_ You can use this spell 1d3 times each day (roll during a full heal-up when you take it). Each time you use the spell, you must wait 1d6 hours before casting it again.
+
+**Target:** One corpse you are touching that has been dead less than a day. Note that creatures that were undead for a longer period before they were killed are not legal targets.
+
+**Effect:** You can ask the corpse a number of yes/no questions that the leftover fragments of personality/spirit within the corpse will attempt to answer truthfully using the information it had when it died.* The magic uses the caster’s knowledge of language so no translation is needed. The first question is free. The second question requires a DC 15 necromancy skill check using Intelligence if the corpse is “friendly,” and Charisma if the corpse is not. Increase the DC by +5 for each subsequent question after the second. If you’re using this spell during battle, each question and answer requires a round.
+
+_Note:_ Just as with the _séance_ ability of the Death Priest talent, there’s always a 10% chance that the spirit summoned is going to lie to you for reasons best known to it and to the GM. The GM rolls a d20 secretly before the corpse provides any answers; a 3+ means the spirit will speak truly, but a 1 or a 2 means it will lie while appearing to be aiming for the truth.
+
+5th level spell: You can now cast this spell 1d4 times per day, targeting corpses or even just heads that have been dead up to a week.
+
+7th level spell: Questions can now be phrased to receive three-word answers, targeting corpses/heads that have been dead up to a month.
+
+9th level spell: Questions can now be phrased to receive one to two sentence answers, targeting corpses/heads or skeletal remains of almost any age.
+
+## Summon Horror (3rd level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a ghoul, as per the summoning rules. The summoned ghoul fights for you until the end of the battle or until it drops to 0 hp, whichever comes first.
+
+As you cast the spell at higher levels, the creature you summon varies, as shown below. The stats for each creature are shown below.
+
+5th level spell: You can now summon a wight.
+
+7th level spell: You can now summon a barrow wight.
+
+9th level spell: You can now summon a greater wight.
+
+### Summoned Ghoul
+
+| Normal 3rd level Spoiler Undead  | Initiative: +8 Vulnerability: holy  Claws and bite +8 vs. AC—8 damage Natural even hit: The target is vulnerable (attacks vs. it have crit range expanded by 2) to attacks by undead until the end of the ghoul’s next turn.  Pound of flesh: The ghoul’s claws and bite attack deals +4 damage against vulnerable targets.  Infected bite: Any creature that is slain by a ghoul and not consumed will rise as a ghoul the next night. | AC PD MD HP | 18 16 12 20 |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Summoned Wight
+
+| Normal 5th level Spoiler Undead  | Initiative: +8 Vulnerability: holy  Sword +10 vs. AC—14 damage Natural even hit or miss: Unless the wight is staggered, the attack also deals 8 ongoing negative energy damage. | AC PD MD HP | 22 18 14 32 |
+|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Summoned Barrow Wight
+
+| Normal 7th level Spoiler Undead  | Initiative: +10 Vulnerability: holy  Sword +12 vs. AC—21 damage Natural even hit or miss: Unless the barrow wight is staggered, the attack also deals 13 ongoing negative energy damage. | AC PD MD HP | 24 20 16 52 |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Summoned Greater Wight
+
+| Normal 9th level Spoiler Undead  | Initiative: +12 Vulnerability: holy  Attack +14 vs AC—40 damage Natural even hit or miss: Unless the greater wight is staggered, the attack also deals 20 ongoing negative energy damage. | AC PD MD HP | 26 22 18 90 |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+## Wave of Decay
+
+Ranged spell
+
+Daily
+
+**Effect:** Choose a nearby enemy. It takes 2d6 negative energy damage for each point on the escalation die. (For example, if the escalation die is 2 when you cast the spell, you’ll deal 4d6 negative energy damage to the target.)
+
+Until the end of the battle, as a free action at the start of each of your turns, repeat the effect above, choosing a target and dealing damage based on the escalation die value.
+
+The effect ends at the end of the battle, when you drop to 0 hp, or when your _wave of decay_ damage drops an enemy to 0 hit points!
+
+5th level spell: 2d12 damage.
+
+7th level spell: 3d12 damage.
+
+9th level spell: 5d12 damage.
+
+### Champion Feat
+
+The spell no longer ends when you drop to 0 hit points or below; instead it ends when you fail a death save.
+
+### Epic Feat
+
+The spell no longer ends when you use it to drop an enemy to 0 hit points; it now ends when it drops a second enemy to 0 hit points.
+
+# 5th Level Spells
+
+## Death’s Call
+
+Ranged spell
+
+Once per battle
+
+Quick action to cast
+
+**Effect:** Choose a creature you can see in the battle. If that creature is the next creature to drop to 0 hp, you heal using a recovery.
+
+7th level spell: When the creature drops, one of your nearby allies can heal using a recovery instead of you.
+
+9th level spell: If the chosen creature is _not_ the next creature in the battle to drop to 0 hp, you still gain 30 temporary hit points.
+
+### Champion Feat
+
+The recovery is now free.
+
+### Epic Feat
+
+If your choice was wrong, you don’t expend the spell and can cast it later this battle. A second failed choice expends the spell.
+
+## Rotting Curse
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 30 ongoing negative energy damage (hard save ends, 16+), and each time the target fails the save, the ongoing negative energy damage increases by 15
+
+**Miss:** 15 ongoing negative energy damage (hard save ends, 16+).
+
+7th level spell: 50 ongoing damage on a hit, with fail increments/miss damage of 25.
+
+9th level spell: 80 ongoing damage on a hit, with fail increments/miss damage of 40.
+
+## Summon Wraith (5th level+)
+
+Ranged spell
+
+Daily
+
+**Effect:** You summon a wraith, as per the summoning rules. This wraith fights for you until the end of the battle or until it drops to 0 hp, whichever comes first.
+
+As you cast the spell at higher levels, you summon multiple wraiths. Stats for the two versions of the wraith summoned by the spell are listed below.
+
+7th level spell: You can now summon two wraiths.
+
+9th level spell: You can now summon two greater wraiths.
+
+### Epic Feat
+
+When you cast _summon wraith_ while the escalation die is 3+, you summon three wraiths or greater wraiths instead of two.
+
+### Summoned Wraith
+
+| Normal 5th level Spoiler Undead  | Initiative: +10 Vulnerability: holy  Ice-cold ghost blade +10 vs. PD—14 negative energy damage Natural 16+: The target is also weakened until the end of its next turn.  C: Spiraling assault +10 vs. PD (1d3 nearby enemies)—10 negative energy damage, and after the attack the wraith teleports to and engages with one target it hit Limited use: The wraith can use spiraling assault only when the escalation die is even.  Flight: The wraith hovers and zooms about.  Ghostly: This creature has resist damage 16+ to all damage (yes, even holy damage) except force damage, which damages it normally. A wraith can move through solid objects, but it can’t end its movement inside them. | AC PD MD HP | 19 14 17 33 |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+### Summoned Greater Wraith
+
+| Normal 7th level Spoiler Undead  | Initiative: +12 Vulnerability: holy  Ice-cold ghost blade +12 vs. PD—20 negative energy damage Natural 16+: The target is also weakened until the end of its next turn.  C: Spiraling assault +10 vs. PD (1d3 nearby enemies)—15 negative energy damage, and after the attack the wraith teleports to and engages with one target it hit Limited use: The wraith can use spiraling assault only when the escalation die is even.  Flight: The wraith hovers and zooms about.  Ghostly: This creature has resist damage 16+ to all damage (yes, even holy damage) except force damage, which damages it normally. A wraith can move through solid objects, but it can’t end its movement inside them. | AC PD MD HP | 21 16 19 47 |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|-------------|
+
+## You Know What to Do
+
+Ranged spell
+
+Daily
+
+**Target:** One or more nearby enemies with 90 hp or fewer, up to a maximum number of targets equal to the escalation die
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target is confused (save ends). Instead of attacking an ally, the target attacks itself.
+
+**Miss:** Negative energy damage equal to your level.
+
+7th level spell: Targets with 160 hp or fewer.
+
+9th level spell: Targets with 260 hp or fewer.
+
+### Champion Feat
+
+The crit range for attacks a confused target makes against itself expands by 4.
+
+### Epic Feat
+
+Increase the hit point threshold of targets by 40 hp.
+
+# 7th Level Spells
+
+## Cone of Corruption
+
+Ranged spell
+
+Daily
+
+**Target:** 1d3 nearby enemies in a group, and any of your allies engaged with those enemies
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 10d10 + Intelligence negative energy damage.
+
+**Natural even hit:** As a hit, plus the target is hampered (save ends).
+
+**Miss:** Half damage.
+
+9th level spell: 2d8 x 10 damage.
+
+## Feigned Defeat
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You lose 10d8 hit points that can’t be prevented in any way. At the start of your next turn, you heal using 3 free recoveries. If you are at 0 hp or below, or even dead, you return to life at 0 hp before healing.
+
+9th level spell: You lose 10d12 hit points.
+
+## Ghost Form
+
+Ranged spell
+
+Daily
+
+**Target:** You
+
+**Effect:** Until the end of the battle, the target gains _flight_ and _resist damage 16+_ against all damage except force damage.
+
+The target also only gains half the normal amount from healing effects, no matter the source.
+
+9th level spell: While in ghost form, you can move through solid objects, but you can’t end your movement inside them.
+
+### Champion Feat
+
+You can now target a nearby willing ally with the spell instead of yourself.
+
+### Epic Feat
+
+You can now target up to two nearby willing allies (including you).
+
+# 9th Level Spells
+
+## Finger of Death
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy with 240 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target drops to 0 hp and dies.
+
+**Miss:** You take 4d10 damage and regain _finger of death_ after the battle.
+
+_**Epic Feat:**_ You can now target an enemy with 320 hp or fewer.
+
+## The Last of the Wine
+
+Ranged spell
+
+Daily
+
+**Target:** One or more nearby enemies, up to a maximum number of targets equal to the escalation die
+
+**Special:** After you cast this spell, you drop to 0 hit points and can’t use the escalation die any longer this battle. Nothing can prevent this change in hit points.
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 3d6 x 10 negative energy damage.
+
+**Miss:** Half damage.
+
+## Vampiric Form
+
+Ranged spell
+
+Daily
+
+**Effect:** Until the end of the battle, or until you drop to –40 hit points, you heal 6d10 + triple your Charisma modifier hit points at the start of each of your turns. In addition, as long as this spell is in effect, you can make the following attack as a free action against each nearby enemy that misses you with an attack with a natural roll of 1–5.
+
+**Attack:** Intelligence + Level vs. MD
+
+**Natural Even Hit:** The target is confused until the end of its next turn.
+
+**Natural Odd Hit:** The target is weakened until the end of its next turn.
+
+# Summoning Rules
+
+These general rules also apply to the druid’s Elemental Caster class talent.
+
+## Standard action spells
+
+Casting a summoning spell generally requires a standard action. The creature(s) you summon appears next to you, though feats or powers might enable you to summon it nearby instead.
+
+## Duration
+
+A summoned creature fights for you until the end of the battle or until it drops to 0 hit points. At 0 hp, summoned creatures are slain and removed from the battle.
+
+## One summoning spell at a time
+
+Each spellcaster can have only a single summoning spell active at a time. If all the creatures from an earlier summoning spell have been slain, you’re free to cast another. Alternatively, you can dismiss your own previously summoned creatures as a quick action to clear the way for a new summoning spell.
+
+## Halfway there
+
+Summoned creatures are not the same as real creatures. They’re partly real, partly magical. Their abilities don’t always match the capabilities of the creatures that the adventurers encounter _for real_. Sometimes this is reflected in a summoned creature’s attacks or abilities. It’s always reflected in a summoned creature’s hit points.
+
+## Hit points
+
+Each summoned creature stat block indicates its base hit points. Starting hit points for summoned creatures are nearly always lower than hit points for non-summoned versions of the same creature. Some class feats might increase the hit points of summoned creatures.
+
+## Actions on arrival
+
+The turn you summon a creature, that creature takes its turn immediately after your turn in initiative order. During its turn, the summoned creature can act like any other creature, taking a standard, move, and quick action. The summoned creature continues to take its turn immediately after you (even if your initiative order changes) until the end of the battle.
+
+## Escalation die
+
+As a rule, summoned creatures don’t benefit from the escalation die. A summoned creature can add the escalation die to attacks, however, if _you use a quick action_ to give it orders or magical reinforcement. The summoned creature then gets to use the escalation die until the start of your next turn, including for opportunity attacks and other attacks that it gets to make during other creatures’ turns.
+
+For example, during the turn you summon the creature, you use a quick action afterward to give it orders, allowing it to use the escalation die bonus. At the start of your next turn, the creature no longer gets to use the escalation die, so you’ll have to use another quick action again during that turn for the creature to keep getting the benefit.
+
+If you’ve summoned a mob of mooks, a single quick action lets every member of the mob use the escalation die.
+
+## Allies
+
+Summoned creatures generally count as your allies (for roleplaying as well as for resolving effects).
+
+## No recoveries, bad healing
+
+Summoned creatures don’t have recoveries. If you cast a healing spell on a summoned creature that requires the use of a recovery, the summoned creature heals hit points equal to your level. If you use an effect that would heal a summoned creature without using a recovery, the summoned creature only heals half the normal hit points of the effect. Temporary hit points still work normally.
+
+## No nastier specials
+
+Creatures you summon don’t use nastier specials.
+
+## Spell or creature
+
+When a summoning spell is cast, it’s definitely a spell. After casting the spell, a summoned creature is a creature.

--- a/Classes/Occultist.md
+++ b/Classes/Occultist.md
@@ -1,0 +1,905 @@
+---
+aliases: [Occultist]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Occultist]
+updated:: 2023-05-07
+---
+
+# Occultist
+
+There is only one occultist, and your one unique thing should account for your knowledge and mastery of powers hidden and occluded.
+
+## Ability Scores
+
+The occultist gains a +2 class bonus to Intelligence or Wisdom, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds for the occultist’s singular knowledge include: librarian of the forbidden, or wandering mystic. Perhaps the occultist is a holy one whose secret knowledge comes from the heavens, or perhaps she has been touched by the abyss, and her secret knowledge comes from someplace far more sinister.
+
+## Gear
+
+At 1st level, the occultist starts with the embroidered robes, secret scrolls, and runic vestments that you would expect from someone with such arcane power. He might have a small item that looks like a harmless bauble but whose markings become more intricate and mesmerizing the longer it’s viewed. To defend himself, he has a staff or a dagger hidden under his robe. He also has some personal possessions left over from his earlier life.
+
+### Gold Pieces
+
+The occultist may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 11      | —           |
+| Heavy      | 13      | -2          |
+| Shield     | 1       | -2          |
+
+### Melee Weapons
+
+|                  | One-Handed                        | Two-Handed               | 
+| ---------------- | --------------------------------- | ------------------------ |
+| Small            | 1d4 dagger                        | 1d6 club, staff          |
+| Light or Simple  | 1d6 (-2 atk) mace, shortsword     | 1d8 (-2 atk) spear       |
+| Heavy or Martial | 1d8 (-4 atk) longsword, warhammer | 1d10 (-4 atk) greatsword |
+
+
+### Ranged Weapons
+
+|                  | Thrown               | Crossbow                    | Bow                   |
+| ---------------- | -------------------- | --------------------------- | --------------------- |
+| Small            | 1d4 dagger, dart     | 1d4 hand crossbow           | —                     |
+| Light or Simple  | 1d6 (-2 atk) javelin | 1d6 (-1 atk) light crossbow | 1d6 (-2 atk) shortbow |
+| Heavy or Martial | —                    | 1d8 (-4 atk) heavy crossbow | 1d8 (-5 atk) longbow  |
+
+## Level Progression
+
+| Occultist          | Total Hit Points           | Total Feats                    | Class Talents (M) | 1st level spell (M) | 3rd level spell (M) | 5th level spell (M) | 7th level spell (M) | 9th level spell (M) | Level-up Ability  | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|-------------------|---------------------|---------------------|---------------------|---------------------|---------------------|-------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | As 1st level PC                | 1 or 2 (3 total)  | 3                   | —                   | —                   | —                   | —                   | Not affected      | ability modifier                |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   | 4                 | 4                   | —                   | —                   | —                   | —                   |                   | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 4                 | 5                   | —                   | —                   | —                   | —                   |                   | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 4                 | 2                   | 3                   | —                   | —                   | —                   |                   | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | 4                 | —                   | 6                   | —                   | —                   | —                   | +1 to 3 abilities | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        | 5                 | —                   | 3                   | 3                   | —                   | —                   |                   | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | 5                 | —                   | —                   | 7                   | —                   | —                   |                   | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | 5                 | —                   | —                   | 4                   | 4                   | —                   | +1 to 3 abilities | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 6                 | —                   | —                   | —                   | 9                   | —                   |                   | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 6                 | —                   | —                   | —                   | 4                   | 5                   |                   | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 6                 | —                   | —                   | —                   | —                   | 10                  | +1 to 3 abilities | 3 x ability modifier            |
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, and Feats are level dependent.
+
+| Ability Bonus                | +2 Intelligence or Wisdom (different from racial bonus)      |
+|------------------------------|--------------------------------------------------------------|
+| Initiative                   | Dex mod + Level                                              |
+| Armor Class (no/light armor) | 11 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense             | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense               | 11 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                   | (6 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                   | 8                                                            |
+| Recovery Dice                | (1d6 x Level) + Con mod                                      |
+| Backgrounds                  | 8 points, max 5 in any one background                        |
+| Icon Relationships           | 3 points (4 at 5th level; 5 at 8th level)                    |
+| Talents                      | 4 (see level progression chart)                              |
+| Feats                        | 1 per Level                                                  |
+| Feats                        | 1 per Level                                                  |
+| Ability Bonus                | +2 Strength or Constitution (different from racial bonus)    |
+
+## Basic Attacks
+
+### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+### Arcane Implements
+
+You use arcane power to alter fate. While wands and staffs are designed for casting spells that are different from the spells you use, given a little time you can bend such an implement to your will.
+
+#### Epic Feat
+
+If you find a magic weapon that isn’t an arcane implement but that calls to your soul, you can bend it to your will and use its attack and damage bonus for spellcasting also. Any other arcane benefits you gain from the weapon are at the GM’s discretion.
+
+### Delayed Magical Healing
+
+Magical healing effects heal you one round after the effect would normally be applied. You gain the healing at the start of the turn of whoever applied the magical healing effect, or at the start of your next turn if you drank a healing potion or found some other way of magically healing yourself during your last turn. This doesn’t apply outside of combat or when you rally.
+
+#### Adventurer Feat
+
+Your baseline hit points are 7 instead of 6.
+
+#### Champion Feat
+
+Once per battle when a healing effect would be applied to you, you can roll a save (11+). If you succeed, you get the healing immediately. If you fail, lose a hit point.
+
+#### Epic Feat
+
+Increase your total recoveries by 1. Once per day as a free action when a natural attack roll of 17 or less hits you, you take only half damage from that attack instead.
+
+### Focus and Spellcasting
+
+Wielding your arcane power of reality requires two steps. First, you take time to focus your mind. Once you have this focus, you can cast a spell. Casting a spell generally expends your focus, though there will be exceptions depending on the spell.
+
+Gaining your focus requires a standard action, and it draws opportunity attacks just like using a ranged attack does. (The “range” in this case is “beyond this world.”) You can cast most of your spells only in response to an event, typically during an enemy’s turn or an ally’s turn.
+
+#### Adventurer Feat
+
+When you cast a spell and retain your focus, you gain a +2 bonus to all defenses until the start of your next turn.
+
+#### Champion Feat
+
+While you have your focus, when an enemy misses you with an attack, it takes psychic damage equal to your level.
+
+#### Epic Feat
+
+The “retain focus” range of your occultist spells increases by 2 (for example, 1–5 would be 1–7).
+
+### Rebuke
+
+With focus, you can pummel someone with their own negative karma. In addition to the spells you normally know based on your level, you also know _karmic rebuke_. There are no feats associated with this spell, but you can improve it with the Superior Rebuke talent.
+
+_Karmic rebuke_ requires a quick action instead of an interrupt action. It’s designed so you can cast it during your turn when you’ve retained your focus, then use your standard action to get your focus back that same turn.
+
+#### Karmic Rebuke
+
+Close-quarters spell
+
+**At-Will**
+
+Quick action to cast; expend focus
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 1d6 + Wisdom psychic damage.
+
+3rd level spell: 3d6 damage.
+
+5th level spell: 5d6 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d10 damage.
+
+### Uniqueness
+
+You’re the only occultist. Your one unique thing should address your identity as the occultist, but you need to contribute your own personal take on the character just like you would with a dwarf fighter or other character class. A character’s _unique_ concerns story material beyond a class description, yours included.
+
+### Spell Choices and Flexible Recharge
+
+Like a standard spellcaster, you choose the spells you will be able to cast after each full heal-up. When you successfully recharge a spell, you can regain any spell of that spell’s level, not necessarily the same spell again. In effect, you roll to recharge that level’s spell slot.
+
+#### Adventurer Feat
+
+Once per day, you can automatically succeed on a recharge roll that’s 6+ (but not 11+ or 16+).
+
+#### Champion Feat
+
+Once per day when you recharge a spell (usually during a quick rest), you can make a recharge roll for a recharge spell even if you haven’t expended that spell (allowing you to have an additional use of that spell available).
+
+#### Epic Feat
+
+Once per day, you can automatically succeed on a recharge roll.
+
+## Class Talents
+
+Choose four of the following class talents. You get an additional occultist class talent at 5th level, and again at 8th level.
+
+### Brain-Melting Secrets
+
+When you hit with a spell attack that deals psychic damage, one target of the attack can’t attack you during its next turn this battle unless you are the only nearby enemy.
+
+#### _**Adventurer Feat**_
+
+The effect works whenever you hit an enemy with a spell, not only one that deals psychic damage.
+
+#### _**Champion Feat**_
+
+You are immune to the confused and dazed conditions. In addition, charm, fear, sleep, and similar mental effects have no effect on you.
+
+#### _**Epic Feat**_
+
+Once per battle when you deal psychic damage to an enemy, if it has 300 hp or fewer, you can also weaken it (save ends).
+
+### Hewer of Truth
+
+You can use an edged melee weapon without an attack penalty. You can use Intelligence instead of Strength for your attack rolls with that weapon, and Wisdom instead of Strength for your damage rolls. In addition, when you hit an enemy engaged with you with a spell, you can cause a small amount of extra harm to that foe with your weapon. The target takes ongoing damage equal to your melee attack miss damage.
+
+#### _**Adventurer Feat**_
+
+Twice per day when an enemy engaged with you misses you with an attack, you can deal ongoing damage to it equal to your Wisdom modifier + Level as you give it a quick slice you’re your weapon (double your Wisdom modifier at 5th level; triple it at 8th level).
+
+#### _**Champion Feat**_
+
+While you have your focus, you gain a +4 bonus to opportunity attacks.
+
+#### _**Epic Feat**_
+
+Once per day when you hit an enemy with _karmic rebuke_, you can make a basic melee attack as a free action.
+
+### Icon Channeler
+
+_You cannot take this talent if you have taken the_ Icon Envoy _talent._
+
+You have three fewer relationship dice than normal (i.e. none at adventurer tier, one at champion tier, and two at epic tier). Instead, when all the characters get to roll relationship dice, you get a 5 to apply to any icon you choose. Like any other character, you can gain relationship dice through extraordinary story events. Remember, just because an icon is out to kill you doesn’t mean you have relationship dice with that icon. Dice represent the utility of a connection in the story not its strength. If you encounter icons other than the standard ones, you can probably talk the GM into letting you align your soul to them, but expect it to cost you.
+
+#### _**Adventurer Feat**_
+
+Choose three icons when you take this feat. Each time you apply your 5 to one of those icons, roll a d6. On a 5–6, change that 5 you’re applying to a 6.
+
+#### _**Champion Feat**_
+
+As the adventurer feat, except that you can also choose three more icons (six total) when you take this feat that allow you to roll the d6 when you apply a 5 to one of them.
+
+#### _**Epic Feat**_
+
+You now get two 5s when the other characters roll icon relationship dice. You can roll a d6 for each 5 if you apply it to a chosen icon from the adventurer and champion feats.
+
+### Icon Envoy
+
+_You cannot take this talent if you have taken the_ Icon Channeler _talent._
+
+Each time the characters roll relationship dice, declare which player will get at least a 5 with one of their icons before the rolls. The player rolls one of their dice for that icon before the others. That first roll counts as a 5 unless the player rolls 6. Roll all other icon dice normally.
+
+#### _**Adventurer Feat**_
+
+Once per level, instead of working with the icon relationships your ally has, give an ally a 5 with an icon they don’t have a relationship with.
+
+#### _**Champion Feat**_
+
+If the first roll for the called icon is even (2, 4, 6), it counts as a 6 instead of a 5.
+
+#### _**Epic Feat**_
+
+If the first roll for the called icon is odd (1, 3, 5), you can declare a second player and one of their icons, and have them roll one icon die the same way.
+
+### Otherworld Shadow
+
+A shadow self haunts and lurks near you most of the time, sometimes an actual shadow on a wall, but other times only a presence sensed just over your shoulder. Once per day as an interrupt action, negate all damage and effects from an enemy’s attacks against you that turn as your shadow absorbs them. Using this talent’s power means you avoid damage from a monster’s multiple attacks if it has them. It also works against multiple attacks from mooks in the same mob working on the same initiative count, but not attacks from multiple non-mook monsters.
+
+#### _**Adventurer Feat**_
+
+Your shadow grants you greater personal resilience: increase your total recoveries by 1.
+
+#### _**Champion Feat**_
+
+Once per day as a free action, you can end all ongoing damage affecting you as you pass off the damage to your shadow.
+
+#### _**Epic Feat**_
+
+Once per day as a free action, you gain a _fear aura_ that affects each enemy attacking you or engaged with you. The hit point threshold for the fear effect is the standard value for a monster five levels above you. Allies are not subject to the fear effect unless they cast a spell that targets you or otherwise interact with you directly in some way. Even in this case, that ally can spend a move action to be immune to your shadow’s _fear aura_ for one round.
+
+| PC Level | Fear Threshold HP (Level + 5) |
+|----------|-------------------------------|
+| 1        | 30                            |
+| 2        | 36                            |
+| 3        | 48                            |
+| 4        | 60                            |
+| 5        | 72                            |
+| 6        | 96                            |
+| 7        | 120                           |
+| 8        | 144                           |
+| 9        | 192                           |
+| 10       | 230                           |
+
+### Stance of Necessity
+
+Twice per day as a quick action, you can gain a +4 bonus to all defenses. The protection lasts until the end of the battle and is in effect while you do NOT have your focus. The bonus also ends when an attack hits you while you don’t have your focus.
+
+#### Adventurer Feat
+
+You can guard a nearby ally instead of yourself (you don’t have to see that ally). The defense bonus ends if either you or the ally is hit while you don’t have your focus.
+
+#### Champion Feat
+
+Your Stance of Necessity uses are now recharge 16+ instead of daily.
+
+#### Epic Feat
+
+When an enemy misses you with an attack while you don’t have your focus, it takes psychic damage equal to triple your Wisdom modifier + Level.
+
+### Superior Rebuke
+
+The first time each round that you expend your focus to cast a spell as an interrupt action and fail to retain your focus, roll a d20 afterward. On an 18–20, you can also cast _karmic rebuke_ as a free action, using that roll in place of your attack roll. You can use this talent again during a later round in the battle once you have your focus again.
+
+#### Adventurer Feat
+
+You can also make the _karmic rebuke_ attack when the d20 roll is 2–4 (low monster MD plus an escalation die bonus often means you’ll still hit).
+
+#### Champion Feat
+
+You can also make a _karmic rebuke_ attack as a free action when you roll a natural 5, 10, 15, or 20 on initiative, even if you don’t have your focus.
+
+#### Epic Feat
+
+One battle per day as a free action, you can enhance your _karmic_ _rebuke_. When you enhance it, enemies are vulnerable (crit range expands by 2) to your _karmic rebuke_ attacks until the end of the battle or until you score a critical hit with the attack.
+
+### Unwinding the Soul
+
+When you cast a spell and roll a natural 11+ with the attack, after the attack you can “unwind” the target as a free action, making it vulnerable to your attacks until the end of the battle. You can unwind only one enemy at a time, so if you choose to unwind a different enemy, the previous foe is no longer vulnerable to your attacks.
+
+#### Adventurer Feat
+
+You can now unwind a second enemy, but if you unwind a third, the first enemy is no longer vulnerable. You can also take this feat multiple times, allowing you to unwind another enemy each time you select it.
+
+#### Champion Feat
+
+You can now unwind an enemy with any attack roll other than a natural 1 when you cast a spell, instead of only on an 11+.
+
+#### Epic Feat
+
+When you attack an enemy that you have begun to unwind and roll a natural 11+ against it, it takes extra psychic damage equal to your Wisdom modifier + Level from all subsequent hits by you or your allies.
+
+### Warp Flesh
+
+When you cast a spell that targets Mental Defense and the target has a higher MD than PD, the attack “twists” and targets PD instead. When a spell twists this way, it deals force damage instead of its normal damage type.
+
+#### Adventurer Feat
+
+When you cast a spell that twists, you gain temporary hit points equal to your Wisdom modifier (double your Wisdom modifier at 5th level; triple it at 8th level).
+
+#### Champion Feat
+
+When you score a critical hit with a spell, the target also takes ongoing force damage equal to double your Wisdom modifier (triple it at 8th level). The ongoing damage isn’t doubled by the crit.
+
+#### Epic Feat
+
+Once per battle when you hit an enemy with a spell, you can negate all of the target’s resistances (hard save ends, 16+). This effect occurs even if the target’s PD is higher than its MD.
+
+## 1st Level Spells
+
+### Better Yet, Here
+
+Close-quarters spell
+
+At-Will
+
+Interrupt action to cast; expend focus
+
+**Trigger:** One of your allies hits a nearby enemy with an attack.
+
+**Target:** The enemy hit by the attack
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target takes 2d6 + Wisdom extra damage from the hit. (If your attack crits, double the damage you are adding to your ally’s attack, but not their base damage.)
+
+**Miss:** The target takes extra damage from the hit equal to the spell level.
+
+**Retain Focus:** 1–5.
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 8d10 damage.
+
+#### Champion Feat
+
+When this attack drops the enemy to 0 hp or drops the last mook of a mob, you don’t expend your focus.
+
+#### Epic Feat
+
+When the triggering ally scores a critical hit with the attack, you don’t expend your focus.
+
+### Bitter Lessons
+
+Close-quarters spell
+
+Recharge 16+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby enemy misses with an attack.
+
+**Target:** The attacking enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 2d6 + Wisdom psychic damage, and the ally the target missed gains the same amount of temporary hit points.
+
+**Miss:** Half damage, and you take the other half of the damage.
+
+**Retain Focus:** 1–15.
+
+3rd level spell: 4d6 damage.
+
+5th level spell: 6d6 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 8d10 damage.
+
+### Brilliant Comeback
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby ally uses a recovery.
+
+**Effect:** The triggering ally can make a basic attack as a free action. Instead of using their attack bonus, that ally uses an attack bonus equal to your Intelligence modifier + 5.
+
+3rd level spell: Intelligence modifier +7.
+
+5th level spell: Intelligence modifier +10.
+
+7th level spell: Intelligence modifier +12.
+
+9th level spell: Intelligence modifier +15.
+
+**Retain Focus:** 1–15
+
+#### Adventurer Feat
+
+The triggering ally adds hit points equal to your Wisdom modifier to the recovery (double your Wisdom modifier at 5th level; triple it at 8th level).
+
+#### Champion Feat
+
+The triggering ally can make an at-will attack instead of a basic attack.
+
+#### Epic Feat
+
+The target of the triggering ally’s attack is vulnerable to that attack.
+
+### Inevitable Fall
+
+Close-quarters spell
+
+Recharge 16+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** One of your allies attacks a nearby enemy and misses.
+
+**Target:** The missed enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 4d8 + Wisdom psychic damage, and 5 ongoing psychic damage.
+
+**Miss:** 5 ongoing psychic damage.
+
+**Retain Focus:** 1–5.
+
+3rd level spell: 8d6 damage, and 10 ongoing damage; 10 ongoing damage on a miss.
+
+5th level spell: 8d10 damage, and 15 ongoing damage; 15 ongoing damage on a miss.
+
+7th level spell: 2d6 x 10 damage, and 25 ongoing damage; 25 ongoing damage on a miss.
+
+9th level spell: 2d10 x 10 damage, and 35 ongoing damage; 35 ongoing damage on a miss.
+
+#### Adventurer Feat
+
+The save to end the ongoing damage, hit or miss, is hard (16+).
+
+### Moment of Karma
+
+Close-quarters spell
+
+At-Will
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby enemy hits you with an attack.
+
+**Target:** The attacking enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 3d6 + Wisdom psychic damage.
+
+**Miss:** Damage equal to spell level.
+
+**Retain Focus:** 1–5.
+
+3rd level spell: 5d6 damage.
+
+5th level spell: 5d10 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 10d10 damage.
+
+#### Adventurer Feat
+
+When the target is staggered before the attack, it’s vulnerable to this attack.
+
+#### Champion Feat
+
+When you hit with this spell, the target also takes ongoing damage equal to double your Wisdom modifier (triple it at 8th level).
+
+#### Epic Feat
+
+Add triple your Wisdom modifier to your miss damage.
+
+### Timely Mistake
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby enemy hits you or an ally with a natural odd attack roll.
+
+**Target:** The attacking enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 1d6 + Wisdom psychic damage, and the target rerolls the attack and must use the lower result.
+
+**Miss:** Damage equal to spell level.
+
+3rd level spell: 3d6 damage.
+
+5th level spell: 5d6 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d10 damage.
+
+**Retain Focus:** 1–5.
+
+#### Adventurer Feat
+
+If the triggering attack targets one of your allies, that ally gains a bonus to all defenses against the rerolled attack equal to your Wisdom modifier.
+
+#### Champion Feat
+
+This spell’s damage dice increase by one size (for example, d6s become d8s).
+
+#### Epic Feat
+
+When you miss with this spell but retain your focus with the roll, the target takes double the miss damage, unless you rolled a 1.
+
+## 3rd Level Spells
+
+### Blood for Blood
+
+Close-quarters spell
+
+At-Will
+
+Interrupt action to cast; expend focus
+
+**Trigger:** One of your allies is staggered by a nearby enemy’s attack.
+
+**Target:** The attacking enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 3d6 + Wisdom psychic damage, and the target is vulnerable (save ends).
+
+**Miss:** Damage equal to spell level.
+
+5th level spell: 5d6 damage.
+
+7th level spell: 5d8 damage.
+
+9th level spell: 7d10 damage.
+
+**Retain Focus:** 1–5.
+
+#### Adventurer Feat
+
+The spell can now trigger when an ally is dazed, weakened, or stunned by an enemy’s attack.
+
+#### Champion Feat
+
+On a hit, the target is now vulnerable until the end of battle.
+
+#### Epic Feat
+
+Your retain focus range with this spell is now 1–15.
+
+### Diversion of Pain
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby enemy of 5th level or lower hits one of your allies with an attack that could have targeted you or a different ally.
+
+**Effect:** The triggering attack now targets you or a different ally of your choice as long as that creature would be a legal target of the attack. Keep the same attack roll.
+
+5th level spell: An enemy of 8th level or less can now trigger this spell.
+
+7th level spell: An enemy of 11th level or less can now trigger this spell.
+
+9th level spell: An enemy of any level can now trigger this spell.
+
+**Retain Focus:** 1–15.
+
+#### Adventurer Feat
+
+The new target of the attack gains a +2 bonus to all defenses against the triggering attack.
+
+#### Champion Feat
+
+You can now cast this spell when a triggering enemy hits you with an attack.
+
+_**Epic Feat**_
+
+The new target gains _resist damage 18+_ against the triggering attack.
+
+### Fortune Smiles
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby ally fails a save against an effect created by a level 1–4 enemy.
+
+**Effect:** That ally gains a bonus to the save equal to your Intelligence modifier.
+
+5th level spell: A level 5–7 effect.
+
+7th level spell: A level 8–10 effect.
+
+9th level spell: A level 11+ effect.
+
+**Retain Focus:** —
+
+#### Champion Feat
+
+Your retain focus range with this spell is now 1–5.
+
+#### Epic Feat
+
+When you cast this spell, choose a second nearby ally. It can roll a save against a save ends effect.
+
+### Strike of the Last Breath
+
+Close-quarters spell
+
+At-Will
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby ally drops to 0 hp or below from the attack of an enemy engaged with it**.**
+
+**Target:** The triggering ally
+
+**Attack:** Intelligence + Level vs. MD
+
+**Effect:** Before the target drops, it can make a basic attack against the attacking enemy as a free action (if possible), but uses your attack roll instead. On a hit, the attack deals normal damage, and the target (your ally) takes less damage from the triggering attack equal to 3d6 + Wisdom modifier.
+
+If the target can’t make a basic attack against the enemy making the triggering attack, this spell has no effect.
+
+**Retain Focus:** 1–5.
+
+5th level spell: Prevent 5d6 damage.
+
+7th level spell: Prevent 5d8 damage.
+
+9th level spell: Prevent 7d10 damage.
+
+#### Adventurer Feat
+
+The target can make an at-will attack instead of a basic attack.
+
+## 5th Level Spells
+
+### Call of Doom
+
+Close-quarters spell
+
+At-Will
+
+Free action to cast
+
+**Trigger:** You drop to 0 hp or below or roll a death save.
+
+**Special:** You can cast this spell without having your focus. If the trigger is you dropping, you cast it before you drop. If the trigger is a death save, you cast it while unconscious.
+
+**Target:** The closest random nearby enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 7d6 + Wisdom psychic damage.
+
+**Retain Focus:** —.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 10d10 damage.
+
+### Crooked Step
+
+Close-quarters spell
+
+Recharge 16+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** An enemy with 100 hp or fewer moves to engage one of your allies and attacks.
+
+**Effect:** The triggering enemy rerolls its attack and uses the roll of your choice. If the attack misses, that enemy isn’t engaged with your ally (i.e. it wasn’t able to move quickly/close enough).
+
+7th level spell: 160 hp or fewer.
+
+9th level spell: 250 hp or fewer.
+
+**Retain Focus:** 1–5.
+
+#### Champion Feat
+
+The ally the triggering enemy is attacking gains a bonus to all defenses against that attack equal to your Intelligence modifier.
+
+#### Epic Feat
+
+When this spell makes the triggering enemy miss with an attack, that enemy takes psychic damage equal to (1d8 x the spell level) + triple your Wisdom modifier. For example, casting at 7th level with a Wisdom of 20, and rolling a 4 on the d8, you’d deal 43 damage (28 + 15).
+
+### Fateful Confrontation
+
+Close-quarters spell
+
+Recharge 16+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby unengaged enemy ends its turn.
+
+**Target:** The triggering enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** Until the start of the target’s next turn, you and each of your allies can make melee attacks against it as if you were engaged with it, as long as the attacker can see the target. Note, when you or an ally attacks the target while nearby or faraway, the attacker isn’t actually engaged with the target.
+
+**Retain Focus:** 1–5.
+
+#### Adventurer Feat
+
+The spell now triggers against a faraway unengaged enemy.
+
+#### Champion Feat
+
+Your retain focus range with this spell is now 1–15.
+
+#### Epic Feat
+
+The spell is now recharge 11+ after battle instead.
+
+  
+  
+
+### Stifle
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** An enemy with 70 hp or fewer fails a disengage check or is targeted with an opportunity attack.
+
+**Target:** The triggering enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target ends its movement, if any, and can’t take any more actions this turn.
+
+**Retain Focus:** 1–10.
+
+7th level spell: 100 hp or fewer.
+
+9th level spell: 160 hp or fewer.
+
+#### Champion Feat
+
+On a hit, the target also takes psychic damage equal to your Level + double your Wisdom modifier (triple it at 8th level).
+
+#### Epic Feat
+
+Increase the triggering hit point threshold by 50.
+
+## 7th Level Spells
+
+### Arcane Loop
+
+Close-quarters spell
+
+Recharge 16+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby ally casts a daily or recharge spell of 7th level or lower.
+
+**Effect:** The triggering ally doesn’t expend that spell.
+
+**Retain Focus:** —.
+
+9th level spell: A spell of 9th level or lower.
+
+#### Champion Feat
+
+The triggering ally also gains temporary hit points equal to double your Wisdom modifier + the level of the triggering spell. In addition, that ally gains the temporary hit points again when they cast that spell this battle.
+
+#### Epic Feat
+
+Your retain focus range with this spell is now 1–15.
+
+### Liberating Blow
+
+Close-quarters spell
+
+At-Will
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A nearby ally fails a disengage check.
+
+**Effect:** The triggering ally can make a basic melee attack against an enemy engaged with it as a free action, but it uses your attack roll instead of its own: Intelligence + Level vs. MD. On a hit, the attack deals normal damage and the disengage check is successful.
+
+**Retain Focus:** 1–5.
+
+9th level spell: The target can now make an at-will or close-quarters attack instead of a basic melee attack, using your attack roll.
+
+#### Epic Feat
+
+The target’s disengage check is successful whether or not the attack hits.
+
+## 9th Level Spells
+
+### Hasten Fate
+
+Close-quarters spell
+
+Recharge 6+ after battle
+
+Interrupt action to cast; expend focus
+
+**Trigger:** A non-mook enemy drops to 0 hp while the escalation die is 3, 4, or 5.
+
+**Effect:** Increase the escalation die by 1.
+
+**Retain Focus:** —.
+
+#### Epic Feat
+
+The spell now triggers when the escalation die is 2–5.
+
+### Rewind the Skeins
+
+Close-quarters spell
+
+Once per level
+
+Standard action to cast; you can only cast this spell out of battle
+
+**Trigger:** You realize that the last two minutes of out of battle roleplay or existence have gone horribly wrong and you want to rewind and try to redirect reality in a manner that you wish.
+
+**Effect:** Reality goes back two minutes. You remember what happened the first time. No one else does. This effect usually can’t rewind past battles—it’s designed for reliving or avoiding social interactions, roleplaying moments, traps, non-combat events, earthquakes, tarrasque appearances (if you could use it before rolling initiative!), and even icon relationship rolls.
+
+#### Epic Feat
+
+Take it back five minutes.

--- a/Classes/Paladin.md
+++ b/Classes/Paladin.md
@@ -1,0 +1,297 @@
+---
+aliases: [Paladin]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Paladin]
+updated:: 2023-05-07
+---
+
+## Paladin
+
+### Ability Scores
+
+Paladins gain a +2 class bonus to Strength or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+### Backgrounds
+
+Possible backgrounds include: city guardsman, combat medic, bodyguard, outlaw hunter, and inquisitor.
+
+### Gear
+
+At 1st level, a paladin starts with a melee weapon or two, a ranged weapon if they want it, armor, a shield, and standard non-magical gear that is suggested by the character’s backgrounds.
+
+#### Gold Pieces
+
+Paladins may start with either 25 gp or 1d6 x 10 gp.
+
+#### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 12      | —           |
+| Heavy      | 16      | —           |
+| Shield     | 1       | —           |
+
+  
+
+#### Melee Weapons
+
+|                  | One-Handed               | Two-Handed               |
+| ---------------- | ------------------------ | ------------------------ |
+| Small            | 1d4 dagger               | 1d6 club                 |
+| Light or Simple  | 1d6 scimitar, shortsword | 1d8 spear                |
+| Heavy or Martial | 1d8 longsword, battleaxe | 1d10 greatsword, halberd |
+
+
+#### Ranged Weapons
+
+| 0                | Thrown           | Crossbow           | Bow          |
+|------------------|------------------|--------------------|--------------|
+| Small            | 1d4 dagger       | 1d4 hand crossbow  | —            |
+| Light or Simple  | 1d6 javelin, axe | 1d6 light crossbow | 1d6 shortbow |
+| Heavy or Martial | —                | 1d8 heavy crossbow | 1d8 longbow  |
+
+
+### Level Progression
+
+| Paladin            | Total Hit Points           | Total Feats                    | Class Talents (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|-------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                   | 3                 | Not affected             | ability modifier                |
+| Level 1            | (8 + CON mod) x 3          | 1 adventurer                   | 3                 |                          | ability modifier                |
+| Level 2            | (8 + CON mod) x 4          | 2 adventurer                   | 3                 |                          | ability modifier                |
+| Level 3            | (8 + CON mod) x 5          | 3 adventurer                   | 3                 |                          | ability modifier                |
+| Level 4            | (8 + CON mod) x 6          | 4 adventurer                   | 3                 | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (8 + CON mod) x 8          | 4 adventurer 1 champion        | 4                 |                          | 2 x ability modifier            |
+| Level 6            | (8 + CON mod) x 10         | 4 adventurer 2 champion        | 4                 |                          | 2 x ability modifier            |
+| Level 7            | (8 + CON mod) x 12         | 4 adventurer 3 champion        | 4                 | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (8 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 5                 |                          | 3 x ability modifier            |
+| Level 9            | (8 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 5                 |                          | 3 x ability modifier            |
+| Level 10           | (8 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 5                 | +1 to 3 abilities        | 3 x ability modifier            |
+
+### Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus                        | +2 Strength or Charisma (different from racial bonus)        |
+|--------------------------------------|--------------------------------------------------------------|
+| Initiative                           | Dex mod + Level                                              |
+| Armor Class (heavy armor)            | 16 + middle mod of Con/Dex/Wis + Level                       |
+| Armor Class (shield and heavy armor) | 17 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense                     | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense                       | 12 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                           | (8 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                           | 8                                                            |
+| Recovery Dice                        | (1d10 x Level) + Con mod                                     |
+| Backgrounds                          | 8 points, max 5 in any one background                        |
+| Icon Relationships                   | 3 points                                                     |
+| Talents                              | 3 (see level progression chart)                              |
+| Feats                                | 1 per Level                                                  |
+
+
+### Basic Attacks
+
+#### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+#### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+### Class Features
+
+All paladins have the Smite Evil class feature.
+
+#### Smite Evil
+
+You can use this talent once per battle, plus an additional number of times per day equal to your Charisma modifier.
+
+As a free action before you make a paladin melee attack roll, you can declare that you’re using a Smite Evil attack. Add +1d12 to the damage roll AND deal half damage with the attack if it misses.
+
+##### Adventurer Feat
+
+Your Smite Evil attacks gain a +4 attack bonus.
+
+##### Champion Feat
+
+Add 2d12 to the damage roll instead of 1d12.
+
+##### Epic Feat
+
+Add 4d12 to the damage roll instead of 2d12.
+
+### Class Talents
+
+Choose three of the following class talents.
+
+You get an additional paladin class talent at 5th level, and again at 8th level.
+
+#### Bastion
+
+You gain +1 AC.
+
+In addition, once per battle when a nearby ally is hit by an attack, you can choose to lose hit points equal to half of that damage, and have your ally take only half of the damage instead. The damage you lose can come from temporary hit points, but isn’t affected by damage resistance and other tricks to avoid the damage.
+
+##### Adventurer Feat
+
+Increase your total number of recoveries by 1.
+
+##### Champion Feat
+
+Once per day, you can use Bastion twice in the same battle.
+
+##### Epic Feat
+
+When you use Bastion now, your ally takes no damage. You still lose hit points equal to half the damage.
+
+#### Cleric Training
+
+Choose one cleric spell of your level or lower. That spell is now part of your powers. (You can change out the spell normally.)
+
+##### Adventurer Feat
+
+You can use your Charisma as the attack ability for cleric spells you can cast.
+
+##### Champion Feat
+
+You can now cast the cleric class feature _heal_ spell twice per day.
+
+##### Epic Feat
+
+Choose two cleric spells instead of one.
+
+#### Divine Domain
+
+**Special:** You can choose Divine Domain a second time, if you wish, at 5th level or at 8th level.
+
+Choose one of the domains listed in the cleric’s class talent list. You gain all the domain’s advantages, including the ability to use the domain’s invocation once per day.
+
+If the domain you choose is designed to help cleric spells and attacks, reinterpret the talent to help your paladin powers. You can use the domain’s feats if you wish; reinterpret them similarly if necessary.
+
+#### Fearless
+
+You are immune to fear abilities and to any non-damage effects of attacks named or described as fear attacks.
+
+In addition, you gain a +1 melee attack bonus against enemies that are not engaged by any of your allies. The bonus increases to +2 against enemies with fear abilities.
+
+##### Adventurer Feat
+
+You gain a +1 bonus to death saves.
+
+##### Champion Feat
+
+You gain a +1 bonus to all saves except death saves.
+
+##### Epic Feat
+
+Your nearby allies gain a +1 bonus to death saves.
+
+#### Implacable
+
+You can roll saves at the start of your turn instead of at the end of your turn. A successful save against ongoing damage, for example, means that you will not take the ongoing damage that turn.
+
+##### Adventurer Feat
+
+You gain a +1 bonus to saves.
+
+##### Champion Feat
+
+Once during your turn as a free action, you can choose to lose hit points equal to your level to reroll a save.
+
+##### Epic Feat
+
+You gain a +1 bonus to Physical Defense and Mental Defense.
+
+#### Lay on Hands
+
+Twice per day as a quick action, you can heal yourself or an ally next to you with a touch. You spend the recovery while the recipient heals as if they had spent the recovery.
+
+##### Adventurer Feat
+
+Add twice your Charisma modifier to the healing provided by Lay on Hands.
+
+##### Champion Feat
+
+Lay on Hands healing uses a free recovery instead of one of your own.
+
+##### Epic Feat
+
+You can now use Lay on Hands four times per day instead of two.
+
+#### Paladin’s Challenge
+
+When you hit an enemy with a melee attack, you can choose to challenge that enemy as a free action. Until the end of the battle, provided that both you and the enemy you’ve challenged are conscious and capable of making an attack, you each take a –4 attack penalty against all other creatures and a –4 penalty to disengage checks from each other.
+
+The attack penalty temporarily deactivates for the attacker when they make an attack roll against their rival, but only until the end of the attacker’s turn. For example, if a creature with more than one attack attacks you first, its subsequent attacks against your allies are without the challenge penalty. However, the attack penalty resets at the end of its turn, so it does not help with opportunity attacks against your allies later in the round.
+
+You can only have one enemy challenged at a time.
+
+Your Paladin’s Challenge ends when…
+
+-   …you or the creature you are challenging falls unconscious or drops to 0 hp.
+    
+-   …you hit a different enemy with an attack (assuming you hit with the –4 penalty).
+    
+-   …the creature flees faraway and you choose to end the challenge.
+    
+
+An enemy can only be the subject of one Paladin’s Challenge at a time; a new challenge overrides the previous one.
+
+In the unlikely case in which two paladins fight each other, any use of Paladin’s Challenge locks them into a challenge that only ends when one of them drops.
+
+##### Adventurer Feat
+
+The attack and disengage penalty for challenged enemies (but not for you) is equal to –4 or to the escalation die, whichever is higher.
+
+##### Champion Feat
+
+You can have two challenges active at the same time against different enemies.
+
+##### Epic Feat
+
+Enemies you challenge are vulnerable to your attacks.
+
+#### Path of Universal Righteous Endeavor
+
+**Special:** You can’t take this talent if you take the Way of Evil Bastards talent.
+
+Your nearby allies gain a +1 bonus to all saves.
+
+##### Adventurer Feat
+
+Once per day, you can reroll your relationship dice with a heroic or ambiguous icon.
+
+##### Champion Feat
+
+All of your melee and ranged attacks deal holy damage.
+
+##### Epic Feat
+
+You gain an additional relationship point with a heroic or ambiguous icon.
+
+#### Way of Evil Bastards
+
+**Special:** You can’t take this talent if you take the Path of Universal Righteous Endeavor talent.
+
+When one of your Smite Evil attacks drops a non-mook enemy to 0 hp, that use of Smite Evil is not expended.
+
+##### Adventurer Feat
+
+Once per day, you can reroll your relationship dice with a villainous or ambiguous icon.
+
+##### Champion Feat
+
+When one of your Smite Evil attacks drops three or more mooks, it is not expended.
+
+##### Epic Feat
+
+You gain an additional relationship point with a villainous or ambiguous icon.

--- a/Classes/Ranger.md
+++ b/Classes/Ranger.md
@@ -1,0 +1,588 @@
+---
+aliases: [Ranger]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Ranger]
+updated:: 2023-05-07
+---
+
+# Ranger
+
+## Ability Scores
+
+Rangers gain a +2 class bonus to Dexterity or Strength, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: trackers, bounty hunters, beast slayers, woodsy assassins, orc slayers, and wanderers.
+
+## Gear
+
+At 1st level, a ranger starts with light armor, a melee weapon or two, a ranged weapon or two, and other mundane gear as suggested by their backgrounds.
+
+### Gold Pieces
+
+Rangers may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 14      | —           |
+| Heavy      | 15      | -2          |
+| Shield     | 1       | -2          |
+
+### Melee Weapons
+
+|                  | One-Handed               | Two-Handed                |
+| ---------------- | ------------------------ | ------------------------- |
+| Small            | 1d4 dagger               | 1d6 club                  |
+| Light or Simple  | 1d6 shortsword, hand axe | 1d8 spear                 |
+| Heavy or Martial | 1d8 longsword, warhammer | 1d10 greatsword, greataxe |
+
+
+### Ranged Weapons
+
+|                  | Thrown           | Crossbow           | Bow          |
+|------------------|------------------|--------------------|--------------|
+| Small            | 1d4 dagger       | 1d4 hand crossbow  | —            |
+| Light or Simple  | 1d6 javelin, axe | 1d6 light crossbow | 1d6 shortbow |
+| Heavy or Martial | —                | 1d8 heavy crossbow | 1d8 longbow  |
+
+## Level Progression
+
+| Ranger Level       | Total Hit Points           | Total Feats                     | Class Talents (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|---------------------------------|-------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                    | 3                 | Not affected             | ability modifier                |
+| Level 1            | (7 + CON mod) x 3          | 1 adventurer                    | 3                 |                          | ability modifier                |
+| Level 2            | (7 + CON mod) x 4          | 2 adventurer                    | 3                 |                          | ability modifier                |
+| Level 3            | (7 + CON mod) x 5          | 3 adventurer                    | 3                 |                          | ability modifier                |
+| Level 4            | (7 + CON mod) x 6          | 4 adventurer                    | 3                 | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (7 + CON mod) x 8          | 4 adventurer 1 champion         | 4                 |                          | 2 x ability modifier            |
+| Level 6            | (7 + CON mod) x 10         | 4 adventurer 2 champion         | 4                 |                          | 2 x ability modifier            |
+| Level 7            | (7 + CON mod) x 12         | 4 adventurer 3 champion         | 4                 | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (7 + CON mod) x 16         | 4 adventurer 3 champion 1 epic  | 5                 |                          | 3 x ability modifier            |
+| Level 9            | (7 + CON mod) x 20         | 4 adventurer 3 champion 2 epic  | 5                 |                          | 3 x ability modifier            |
+| Level 10           | (7 + CON mod) x 24         | 4 adventurer 3 champion 3 epic  | 5                 | +1 to 3 abilities        | 3 x ability modifier            |
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus             | +2 Strength, Dexterity, or Wisdom (different from racial bonus) |
+|---------------------------|-----------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                                 |
+| Armor Class (light armor) | 14 + middle mod of Con/Dex/Wis + Level                          |
+| Physical Defense          | 11 + middle mod of Str/Con/Dex + Level                          |
+| Mental Defense            | 10 + middle mod of Int/Wis/Cha + Level                          |
+| Hit Points                | (7 + Con mod) x Level modifier (see level progression chart)    |
+| Recoveries                | 8                                                               |
+| Recovery Dice             | (1d8 x Level) + Con mod                                         |
+| Backgrounds               | 8 points, max 5 in any one background                           |
+| Icon Relationships        | 3 points                                                        |
+| Talents                   | 3 (see level progression chart)                                 |
+| Feats                     | 1 per Level                                                     |
+
+## Basic Attacks
+
+### Melee Attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength OR Dexterity + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+### Ranged Attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** Damage equal to your level
+
+## Class Talents
+
+Choose three of the following class talents, or put two talents into Animal Companion, and one talent elsewhere.
+
+You get an additional ranger class talent at 5th level, and again at 8th level.
+
+### Animal Companion
+
+**Special:** Unlike most class talents, this talent can take up to two ranger class talent slots. Spending one talent makes you an Animal Companion initiate. Spending two makes you an Animal Companion adept.
+
+You have a normal-sized animal companion that fights alongside you in battle. See Animal Companion Rules.
+
+If you would rather have a smaller beast as a pet, see the Ranger’s Pet talent.
+
+### Archery
+
+Once per battle, reroll one of your missed ranged attacks.
+
+#### Adventurer Feat
+
+Your Archery rerolls gain a +2 attack bonus and the attack’s crit range expands by 1.
+
+#### Champion Feat
+
+Once per day, you can use Archery twice in the same battle.
+
+#### Epic Feat
+
+Once per day, you can turn a normal hit with a ranger ranged attack into a critical hit.
+
+### Double Melee Attack
+
+When fighting with two one-handed melee weapons, your default option is to make a double melee attack.
+
+Your weapon damage die drops one notch, usually from d8s to d6s. If your first attack is a natural even roll (hit or miss), you can make a second attack as a free action.
+
+If you decide you don’t want to try for a double melee attack while fighting with two one-handed weapons, declare it before rolling your attack; the single attack will deal the normal damage dice instead of using reduced damage dice.
+
+#### Adventurer Feat
+
+Your second attack gains a +2 attack bonus if it is against a different target.
+
+#### Champion Feat
+
+Once per battle, use Double Melee Attack after an odd attack roll.
+
+#### Epic Feat
+
+Each turn, you can pop free of one enemy before one attack roll that is part of a Double Melee Attack. You can also use your move action in between your two attacks if you wish.
+
+### Double Ranged Attack
+
+When you attack with a ranged weapon that does not need to be reloaded, your default option is to make a double ranged attack.
+
+Your weapon damage die drops one notch, usually from d8s to d6s. If your first attack is a natural even roll (hit or miss), you can make a second attack as a free action.
+
+If you decide you don’t want to try for a double ranged attack when firing your bow or other ranged weapon, declare it before rolling your attack; the single attack will deal the normal damage dice instead of using reduced damage dice.
+
+#### Adventurer Feat
+
+Your second attack gains a +2 attack bonus if it is against a different target.
+
+#### Champion Feat
+
+Once per battle, you can use Double Ranged Attack after an odd attack roll.
+
+#### Epic Feat
+
+Each turn, you can pop free of one enemy before one attack roll that is part of a Double Ranged Attack. You can also use your move action in between your two attacks if you wish.
+
+### Favored Enemy
+
+Choose a specific monster type (e.g. aberration, beast, construct, demon, devil, dragon, elemental, giant, humanoid*, ooze, plant, spirit, or undead**)**. The crit range of your ranger attacks against that type of enemy expands by 2.
+
+*Choosing humanoid: Unlike other favored enemies, choosing humanoid as your favored enemy takes up two ranger class talent slots.
+
+#### Adventurer Feat
+
+You can change your favored enemy by meditating when you take a full heal-up.
+
+#### Champion Feat
+
+Your crit range for attacks against favored enemies expands by 1 (to +3).
+
+#### Epic Feat
+
+Choose a second non-humanoid monster type as a favored enemy.
+
+### Fey Queen’s Enchantments
+
+Choose one daily or recharge spell of your level or lower from the sorcerer class. You can cast this spell as if you were a sorcerer (though you can’t gather power).
+
+#### Adventurer Feat
+
+You can choose which ability score you want to use as the attack ability for sorcerer spells you can cast.
+
+#### Champion Feat
+
+You can now choose from sorcerer at-will spells.
+
+#### Epic Feat
+
+You gain an additional sorcerer spell of your choice that is your level or lower; a total of two from this talent.
+
+### First Strike
+
+The first time you attack an enemy during a battle, your crit range for that attack expands by 2 (usually to 18+). A mob of mooks counts as a single enemy.
+
+#### Adventurer Feat
+
+The crit range of your First Strike attacks expands by 1 (to +3).
+
+#### Champion Feat
+
+Once per day, deal triple damage with a First Strike crit instead of double damage.
+
+#### Epic Feat
+
+Whenever you hit with a First Strike attack, you can reroll your damage once and use the higher roll.
+
+### Lethal Hunter
+
+Once per battle as a free action, choose an enemy. The crit range of your attacks against that enemy expands by 2 for the rest of the battle. A mob of mooks counts as a single enemy.
+
+#### Adventurer Feat
+
+The crit range of your Lethal Hunter attacks expands by 1 (to +3).
+
+#### Champion Feat
+
+One battle per day, you can use Lethal Hunter against two different enemies.
+
+#### Epic Feat
+
+Your Lethal Hunter crits deal triple damage instead of double damage while the escalation die is 3+.
+
+### Ranger ex Cathedral
+
+Choose one daily or recharge spell of your level or lower from the cleric class. You can cast this spell as if you were a cleric. You can change your chosen spell each time you take a full heal-up.
+
+#### Adventurer Feat
+
+You can cast the cleric class feature _heal_ spell once per battle.
+
+#### Champion Feat
+
+You can now choose from cleric at-will spells.
+
+#### Epic Feat
+
+You gain an additional cleric spell of your choice that is your level or lower; a total of two from this talent.
+
+### Ranger’s Pet
+
+You have a small animal or beast that accompanies you on your adventures. Use the rules from the Wizard’s Familiar talent with the following differences:
+
+1.  The creature is your pet or friend instead of your familiar.
+    
+2.  Your pet is fully natural rather than partially magical.
+    
+3.  Your pet can end up with more abilities, if you choose.
+    
+
+#### Adventurer Feat
+
+Your pet gains a third ability.
+
+#### Champion Feat
+
+Your pet gains a fourth ability.
+
+#### Epic Feat
+
+Your pet gains a fifth ability.
+
+### Tracker
+
+You have the Tracker background at its full possible bonus of +5, without having to spend your normal background points on it. You are an expert wilderness tracker, capable of reading clues from the environment that others can’t perceive. Tracking doesn’t work well, however, in heavily traveled urban environments.
+
+In addition, you have the terrain stunt power.
+
+**Terrain stunt:** At the start of each battle in a non-urban environment, roll a d6. Any time after the escalation die reaches that number, you’ll be able to use a quick action to execute a terrain stunt. Normally you can only use terrain stunt once per battle, but circumstances, geography, or excellent planning may suggest that you can pull it off more than once.
+
+Terrain stunts are improvisational effects that play off your preternatural understanding of the wilderness and all the diverse forms of the natural world. Things like knocking a hornets nest no one had noticed onto your enemy’s head, maneuvering a foe onto a soggy patch of ground that slows them down, shooting the cap off a mushroom spore in a dungeon that erupts on your enemies, getting your enemy’s sword wedged into a stalactite, finding the tree branch that lets you vault up to attack the flying demon that thought it was out of axe range, and similar types of actions.
+
+#### Adventurer Feat
+
+Your grasp of the way the world is put together increases; you now can use terrain stunt in urban environments.
+
+#### Champion Feat
+
+You can track as well in urban areas as you do in the wilderness.
+
+#### Epic Feat
+
+You can track flying creatures and creatures that normally wouldn’t be trackable, and there’s the possibility that even teleports give you a sense of direction.
+
+### Two-Weapon Mastery
+
+You gain a +1 attack bonus when fighting with a one-handed melee weapon in each hand.
+
+#### Adventurer Feat
+
+When you fight with two one-handed melee weapons, increase the damage you deal with missed attacks by adding your level to it. Most of your basic melee attacks, therefore, will deal double your level as miss damage.
+
+#### Champion Feat
+
+If you fight with two one-handed melee weapons, whenever an enemy makes a melee attack against you and rolls a natural 1, you can make an opportunity attack against that foe as a free action.
+
+#### Epic Feat
+
+One battle per day, increase the damage you deal with missed attacks to triple your level instead of double your level (from Two-Weapon Mastery).
+
+## Animal Companion Rules
+
+You have a devoted animal companion who fights alongside you like a member of your adventuring party.
+
+If you have a single talent invested into Animal Companion, you are an Animal Companion initiate. If you invested two talents into Animal Companion, you are an Animal Companion adept.
+
+These are the same rules as for the druid.
+
+### Calling to Battle
+
+When you roll initiative, you may choose whether you want your animal companion to take part in the battle. You may also call your animal companion during the battle with a quick action.
+
+Animal Companion initiates may only call their animal companion once every other battle. The animal companion may not fight in two battles in a row—even between full heal-ups, adventures, or gaining new levels. Animal Companion adepts don’t have this limitation; their animal companion can fight in every battle if the adept so chooses.
+
+### Recoveries
+
+As an initiate, add a recovery to your total recoveries. As an adept, add two recoveries to your total recoveries. You can use a recovery on yourself or your animal companion.
+
+### Actions
+
+Your animal companion acts on your initiative turn, either immediately before or after you, depending on the animal type.
+
+Your animal companion moves gets a move action and a standard action, but not a quick action.
+
+If you have powers that care about the “first time you attack an enemy,” an attack by your animal companion counts as your attack.
+
+### Animal Harm
+
+Your animal companion can be healed like an ally. If it gets healed without you being healed, it uses one of your recoveries. When you use a recovery while next to your animal companion (including being engaged with the same enemy), your animal companion is also healed using a free recovery.
+
+Instead of dying like a monster or NPC at 0 hp, your animal companion follows PC rules for falling unconscious at 0 hp and dying after four failed death saves or when its negative hit points equal half its normal hit points. If your animal companion dies, it’s gone for the battle, though you can call it (or another one) to fight in the next battle (as an adept) or the in the battle after that (as an initiate). That animal companion will be one level lower than an animal companion would normally be, i.e. two levels below you. At the start of the next battle, bump the animal companion up to its proper level, i.e. one below you.
+
+### Stats & Levels
+
+Each animal companion has roughly the same base stats as listed below.
+
+Your animal companion is always one level lower than you. As a 1st level ranger, you’ll have a level 0 animal companion. Once you gain a level, your animal companion rises to 1st level.
+
+On top of the base stats, each type of animal has a zoologically appropriate power or advantage.
+
+### Companion Bonuses
+
+Each type of animal companion is a little different.
+
+#### Bear (also Giant Badger, Wolverine)
+
+**Acts:** After ranger
+
+**Advantage:** The bear gains temporary hit points equal to its level each time it hits with an attack.
+
+#### Champion Feat
+
+The temporary hit points increase to double its level.
+
+#### Boar (also Spiky Lizard)
+
+**Acts:** Before ranger
+
+**Advantage:** The boar gains a +1 attack bonus when it moves before its attack during the same turn.
+
+#### Eagle (also Falcon, Hawk, Owl, Vulture)
+
+**Acts:** Before ranger
+
+**Advantage:** It flies! Its melee damage die is dropped by one size (d6 at level 0).
+
+#### Panther (also Lion, Tiger)
+
+**Acts:** Before ranger
+
+**Advantage:** The panther’s crit range expands by 2 against enemies with lower initiative.
+
+#### Snake (also Giant Spider, Poison Toad)
+
+**Acts:** After ranger
+
+**Advantage:** The snake also deals ongoing poison damage equal to twice your level on a natural attack roll of 18+.
+
+#### Champion Feat
+
+The ongoing damage is three times your level instead.
+
+#### Epic Feat
+
+The ongoing damage is four times your level instead.
+
+#### Wolf (also Big Dog, Coyote, Hyena, Jackal)
+
+**Acts:** After ranger
+
+**Advantage:** The wolf gains a +1 attack bonus against enemies its master attacked the same turn, or against enemies engaged with its master.
+
+### Baseline Stats
+
+Use the following stats as the baseline for your animal companion. Remember that your companion stays a level lower than you. Generally your companion’s Physical Defense should be higher than its Mental Defense, but you could flip that if you have a good explanation.
+
+| Level | Attack     | Damage | AC | PD (or MD) | MD (or PD) | HP        |
+|-------|------------|--------|----|------------|------------|-----------|
+| 0     | +5 vs. AC  | d8     | 16 | 14         | 10         | 20 (10)   |
+| 1     | +6 vs. AC  | d10    | 17 | 15         | 11         | 27 (13)   |
+| 2     | +7 vs. AC  | 2d6    | 18 | 16         | 12         | 36 (18)   |
+| 3     | +9 vs. AC  | 3d6    | 19 | 17         | 13         | 45 (22)   |
+| 4     | +10 vs. AC | 4d6    | 21 | 19         | 15         | 54 (27)   |
+| 5     | +11 vs. AC | 5d6    | 22 | 20         | 16         | 72 (36)   |
+| 6     | +13 vs. AC | 6d6    | 23 | 21         | 17         | 90 (45)   |
+| 7     | +14 vs. AC | 7d6    | 25 | 23         | 19         | 108 (54)  |
+| 8     | +15 vs. AC | 8d6    | 26 | 24         | 20         | 144 (72)  |
+| 9     | +17 vs. AC | 9d6    | 27 | 25         | 21         | 180 (90)  |
+| 10    | +18 vs. AC | 10d6   | 28 | 26         | 22         | 216 (108) |
+
+### Animal Companion Feats
+
+Ranger animal companion feats are designed so that they do not build on each other. Unlike other feats, you don’t have to take animal companion feats progressively, one after the other as long as you qualify for the correct tier.
+
+#### Adventurer Feats
+
+-   Once per day, your animal companion can attack twice in a round with a standard action.
+    
+-   Once per battle, your animal companion can turn a disengage success by an enemy it is engaged with into a failure.
+    
+-   Once per day, reroll one of your animal companion’s missed attack rolls.
+    
+-   Your animal companion adds the escalation die to its attacks.
+    
+
+#### Champion Feats
+
+-   Once per day, your animal companion can force an enemy to reroll an attack that hit it.
+    
+-   Your Lethal Hunter talent also applies to your animal companion.
+    
+-   Increase your animal companion’s Physical Defense and Mental Defense by +1.
+    
+
+#### Epic Feats
+
+-   Increase your animal companion’s damage die by one size (for example, from d6s to d8s, or d8s to d10s).
+    
+-   Increase your animal companion’s AC by +1.
+    
+
+### Animal Companion Spells
+
+As an Animal Companion adept, you gain a number of spells to help your animal companion—or another’s—fight better. You don’t have to choose the spells you know ahead of time. You can cast any spell of your level or lower, limited only by the number of daily spells you get. Once you cast a particular daily spell, no matter its level, you can’t cast it again until you take your next full heal-up.
+
+Animal Companion spells are not available to Animal Companion initiates.
+
+| Ranger Level | Multiclass Level | Daily Spells | Spells are Cast At |
+|--------------|------------------|--------------|--------------------|
+| 1            | 1, 2             | 1            | 1st level          |
+| 2            | 3                | 2            | 1st level          |
+| 3            | 4                | 2            | 3rd level          |
+| 4            | 5                | 2            | 3rd level          |
+| 5            | 6                | 3            | 5th level          |
+| 6            | 7                | 3            | 5th level          |
+| 7            | 8                | 3            | 7th level          |
+| 8            | 9                | 4            | 7th level          |
+| 9            | 10               | 4            | 9th level          |
+| 10           | -                | 4            | 9th level          |
+
+### 1st Level Spells
+
+#### Pack Link
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, when the target attacks an enemy that is engaged with you, increase the target’s melee attack damage dice for that attack by one size, up to a maximum of d12.
+
+5th level spell: The target’s basic melee attacks now deal half damage on a natural even miss.
+
+7th level spell: The target’s basic melee attacks now deal half damage on any miss.
+
+#### Vitality
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** The target heals using a free recovery.
+
+3rd level spell: In addition, the target heals hit points equal to your Wisdom modifier at the start of each of its turns until the end of the battle or until it drops to 0 hit points.
+
+5th level spell: The healing the target gains at the start of its turn is now double your Wisdom modifier.
+
+7th level spell: The healing the target gains at the start of its turn is now triple your Wisdom modifier.
+
+9th level spell: The first time this battle that the target drops to 0 hit points, you can roll a normal save. If you succeed, the target heals using one of your recoveries.
+
+### 3rd Level Spells
+
+#### Magic Fang
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** If the target already adds the escalation die to its attacks, it gains a +2 attack bonus until the end of the battle. If not, it now adds the escalation die to its attacks until the end of the battle.
+
+5th level spell: The target’s crit range expands by 2.
+
+9th level spell: The target’s crit range expands by a total of 4.
+
+### 5th Level Spells
+
+#### Armor of Shell & Spirits
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Special:** You must spend a recovery to cast this spell.
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, the target gains _resist damage 12+_ against attacks that target AC.
+
+7th level spell: Resistance now includes attacks that target PD.
+
+9th level spell: Resistance increases to _resist damage 14+._
+
+### 7th Level Spells
+
+#### Blood is Strong
+
+Ranged spell
+
+Quick action to cast
+
+Daily
+
+**Target:** One nearby animal companion
+
+**Effect:** Until the end of the battle, when the target hits with a melee attack, you heal hit points equal to 1d10 + your Wisdom modifier.
+
+9th level spell: You now heal hit points equal to 2d10 + double your Wisdom modifier.
+
+### 9th Level Spells
+
+#### Spirit Guardian
+
+Ranged spell
+
+Free action to cast
+
+Daily
+
+**Special Trigger:** You drop to 0 hp or below while your animal companion is nearby and still above 0 hp.
+
+**Effect:** Your spirit trades places with the spirit of your animal companion. You now occupy the body of your animal companion, using its current hit points, defenses, and attacks (and the effects of any spells cast upon it earlier).
+
+You can’t cast spells or use your normal humanoid powers and class features while in your companion’s body. You can either keep fighting as your animal companion or you can roll a normal save as a quick action once during each of your turns; if you succeed, your body and your animal companion's body swap places while your spirits return to their proper bodies. You keep the hit points of the animal companion before you rolled the save, but can heal using a recovery when the swap is complete, if you wish. Returning to your own partially-healed body thanks to the successful save ends the spell's effect.
+
+While your animal companion is in your body, it can roll death saves and be healed. If it becomes conscious it can attack using its basic melee attacks, but it doesn’t have access to any of your spells or powers. Any failed death saves remain with the spirit that failed them, not the body.

--- a/Classes/Rogue.md
+++ b/Classes/Rogue.md
@@ -1,0 +1,660 @@
+---
+aliases: [Rogue]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Rogue]
+updated:: 2023-05-07
+---
+
+# Rogue
+
+## Ability Scores
+
+Rogues gain a +2 class bonus to Dexterity or Charisma, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: street thug, cat burglar, diplomat, professional gambler, courtier, jewel thief, acrobat, con artist, bartender, spy master, pirate, dandy, rat catcher.
+
+## Gear
+
+At 1st level, rogues start with the clothes on their back and the dice in their pockets. They also start with various bladed weapons and some armor. Plus various oddments suggested by their backgrounds.
+
+### Gold Pieces
+
+Rogues may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 11      | —           |
+| Light      | 12      | —           |
+| Heavy      | 13      | –2          |
+| Shield     | 1       | -2          |
+
+### Melee Weapons
+
+|                  | One-Handed                       | Two-Handed               |
+|------------------|----------------------------------|--------------------------|
+| Small            | 1d8 dagger                       | 1d6 club                 |
+| Light or Simple  | 1d8 shortsword, wicked knife     | 1d8 spear                |
+| Heavy or Martial | 1d8 (-2 atk) longsword, scimitar | 1d10 (-2 atk) greatsword |
+
+### Ranged Weapons
+
+|                  | Thrown           | Crossbow                    | Bow                  |
+|------------------|------------------|-----------------------------|----------------------|
+| Small            | 1d4 dagger       | 1d4 hand crossbow           | —                    |
+| Light or Simple  | 1d6 javelin, axe | 1d6 light crossbow          | 1d6 shortbow         |
+| Heavy or Martial | —                | 1d8 (–1 atk) heavy crossbow | 1d8 (-2 atk) longbow |
+
+## Level Progression
+
+| Rogue Level        | Total Hit Points           | Total Feats                    | Powers Known (M) | Power Pool Available (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|------------------|--------------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                   | 4                | 1st level                | Not affected             | ability modifier                |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   | 4                | 1st level                |                          | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 5                | 1st level                |                          | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 5                | 3rd level                |                          | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | 6                | 3rd level                | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        | 6                | 5th level                |                          | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | 7                | 5th level                |                          | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | 7                | 7th level                | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | 8                | 7th level                |                          | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | 8                | 9th level                |                          | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | 9                | 9th level                | +1 to 3 abilities        | 3 x ability modifier            |
+
+Note: Although not listed on the table, this class gets three talents. It does not gain more at higher levels.
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus             | +2 Dexterity or Charisma (different from racial bonus)       |
+|---------------------------|--------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                              |
+| Armor Class (light armor) | 12 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense          | 12 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense            | 10 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                | (6 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                | 8                                                            |
+| Recovery Dice             | (1d8 x Level) + Con mod                                      |
+| Backgrounds               | 8 points, max 5 in any one background                        |
+| Icon Relationships        | 3 points                                                     |
+| Talents                   | 3                                                            |
+| Feats                     | 1 per Level                                                  |
+
+## Basic Attacks
+
+### Melee attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** Damage equal to your level
+
+### Ranged attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** Damage equal to your level
+
+## Class Features
+
+All rogues fight better when they gain momentum, are good at stabbing enemies in the back, and have a knack for avoiding the traps that their clueless allies would stumble into.
+
+### Momentum
+
+Many of the rogue’s powers function only when the rogue has momentum.
+
+You gain momentum by hitting an enemy with an attack.
+
+You lose momentum when you are hit by an attack.
+
+The default is that you can use momentum powers without losing momentum, but a few powers specify that you must spend your momentum to use them. You don’t have to use attacks that require momentum against the foe you hit to gain that momentum.
+
+Momentum powers that do not require you to spend your momentum are generally classified as interrupt actions. You can only use one interrupt action a round, which keeps your momentum powers from dominating the battle.
+
+### Sneak Attack
+
+Once per round when you make a rogue melee weapon attack against an enemy engaged with one or more of your allies, you can deal extra damage if your attack hits.
+
+| Rogue Level | Extra Damage |
+|-------------|--------------|
+| 1           | +1d4         |
+| 2           | +1d6         |
+| 4           | +2d6         |
+| 6           | +3d6         |
+| 8           | +5d6         |
+| 10          | +7d6         |
+
+#### Adventurer Feat
+
+Your Sneak Attack feature also works the first round of combat against enemies with a lower initiative than you.
+
+#### Champion Feat
+
+Your Sneak Attack feature also works against enemies who are confused, dazed, stunned, vulnerable to your attack, or weakened.
+
+#### Epic Feat
+
+Once per battle when you miss with an attack that would have allowed you to deal Sneak Attack damage, replace the normal miss damage with your full Sneak Attack damage.
+
+### Trap Sense
+
+Even rogues whose backgrounds don’t have anything to do with noticing, avoiding, or disarming traps have a unique knack for dealing with traps.
+
+If a rogue’s skill check involving a trap is a natural even failure, the rogue can reroll the skill check once. If a trap’s attack roll against a rogue is a natural odd roll, the rogue can force the trap to reroll the attack once.
+
+#### Adventurer Feat
+
+The trap attack reroll can also apply to a nearby ally of the rogue as the rogue shouts a warning or acts to prevent the trap from hitting.
+
+#### Champion Feat
+
+You gain a +3 bonus to skill check rerolls you make against traps.
+
+#### Epic Feat
+
+You only take half damage from trap attacks.
+
+## Class Talents
+
+Choose three of the following class talents.
+
+### Cunning
+
+You can use your Intelligence in place of your Charisma for any rogue attacks, talents, or powers that use Charisma (e.g. _shadow walk_ and _slick feint_). You also gain two extra points of backgrounds to spend on knowledge-related backgrounds and gain a +2 bonus to skill checks involving traps.
+
+#### Adventurer Feat
+
+You gain a +1 bonus to Mental Defense.
+
+#### Champion Feat
+
+Once per battle, reroll a save against an effect from an attack that originally hit your Mental Defense.
+
+#### Epic Feat
+
+Your once-per-battle save reroll is now once per save.
+
+### Improved Sneak Attack
+
+Your Sneak Attack damage is better than other rogues. Use the following Sneak Attack bonus damage progression instead.
+
+| Rogue Level | Extra Damage |
+|-------------|--------------|
+| 1           | +1d6         |
+| 2           | +1d8         |
+| 4           | +2d8         |
+| 6           | +3d8         |
+| 8           | +5d8         |
+| 10          | +7d8         |
+
+#### Adventurer Feat
+
+Once per day as a free action, you can add your Sneak Attack damage to any hit against one target that would not otherwise have qualified for the damage.
+
+#### Champion Feat
+
+Once per day, roll d20s for your Sneak Attack damage instead of d8s.
+
+#### Epic Feat
+
+One battle per day, ignore the limitation that you can use Sneak Attack damage only once per round.
+
+### Murderous
+
+Against staggered enemies, your crit range with rogue attacks expands by 2.
+
+#### Adventurer Feat
+
+You gain a +2 attack bonus against staggered enemies.
+
+#### Champion Feat
+
+Your crit range against staggered enemies expands by 2 (now +4).
+
+#### Epic Feat
+
+Whenever a staggered enemy misses you with a melee attack, it’s vulnerable to your attacks for the rest of the battle.
+
+### Shadow Walk
+
+You gain the _shadow walk_ at-will power:
+
+As a move action before you have used your standard action this turn, if you are not engaged, you can make the following “attack” against all nearby enemies, targeting the enemy among them with the highest Mental Defense.
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** Remove yourself from play. At the start of your next turn, return anywhere nearby that you could have moved to normally during your turn, and deal double damage with your first rogue attack that turn.
+
+**Miss:** No effect. You can’t attempt to _shadow walk_ again until your next turn, but you still have your standard action this turn.
+
+#### Adventurer Feat
+
+On a miss, you can still use your move action normally (but still can’t _shadow walk_ this turn).
+
+#### Champion Feat
+
+Twice per day, you can reroll the rogue attack that follows your successful use of _shadow walk_.
+
+#### Epic Feat
+
+Twice per day, you can reappear from your _shadow walk_ in a nearby location you wouldn’t have been able to reach unimpeded physically, for instance, on the other side of a portcullis or door, or high up a wall.
+
+### Smooth Talk
+
+Once per day, convince your GM with an amazing line of patter while you are using social skills to speak or interact with NPCs associated with a particular icon. If the GM is convinced by your patter, roll a normal save (11+). If you succeed, for the rest of the day you can function as if you have a 2-point positive relationship with the icon who seems to be in play. Thanks to your amazing gift of gab, for a short time, it’s more or less true. (Note that these points replace any points you normally have with the icon rather than adding to them.)
+
+Failure on the Smooth Talk save generally arouses suspicions.
+
+#### Adventurer Feat
+
+Add your Charisma modifier to your Smooth Talk save rolls.
+
+#### Champion Feat
+
+Success with your Smooth Talk talent gives you a 3-point positive relationship instead.
+
+#### Epic Feat
+
+Even if you fail your Smooth Talk save, you get a 2-point conflicted relationship with the icon because the people you’re speaking with can’t be sure.
+
+### Swashbuckle
+
+Once per battle as a quick action, you can spend your momentum to pull off a daring stunt the likes of which others could scarcely conceive. You may make an attack as part of the stunt, but you’ll need to roll normally for the attack. This is an improvisational talent.
+
+As a swashbuckler, you do not need a difficult skill check to pull the stunt off.
+
+### Thievery
+
+You have the Thief background at its full possible bonus of +5, without having to spend your normal background points on it.
+
+#### Adventurer Feat
+
+Regardless of your level, you gain the bonus power _thief’s strike_ in addition to your normal number of powers.
+
+#### Champion Feat
+
+Once per day, you can deal full damage with _thief’s strike_ instead of half damage.
+
+#### Epic Feat
+
+Twice per level, you can steal something with a successful _thief’s strike_ that you would not be able to steal ordinarily, but that would require a bit of magic, e.g. a dream, a spell, someone’s hope, a memory. The theft probably isn’t going to be permanent, but it should last at least a day or two. You can’t steal the same thing twice.
+
+### Tumble
+
+You gain a +5 bonus to disengage checks. In addition, while you are moving, if an enemy moves to intercept you, you can make one disengage roll per intercepting enemy as a free action to avoid that enemy, but you must stop the first time you fail any of those disengage checks.
+
+#### Adventurer Feat
+
+You ignore the penalty for disengaging from more than one enemy at a time.
+
+#### Champion Feat
+
+One battle per day as a free action, you can declare that you’re a tumbling fool and automatically succeed on your first disengage check each turn.
+
+#### Epic Feat
+
+Whenever you take critical hit damage, roll a hard save (16+). If you succeed, you somehow tumbled out of the way of whatever was about to hit you, and instead only take damage equal to the attacker’s level.
+
+## 1st Level Powers
+
+Evasive Strike
+
+Melee attack
+
+At-Will
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage, and you can pop free from the target.
+
+**Miss:** Damage equal to your level.
+
+### Adventurer Feat
+
+If you drop the target with your _evasive strike_ attack, you can pop free from all enemies instead.
+
+### Champion Feat
+
+If you hit with _evasive strike_ and the natural attack roll was even, you gain a +2 bonus to AC and PD against the next attack that targets you this battle (no joy if it’s an attack vs. MD).
+
+### Epic Feat
+
+Ok. Thanks to your slippery mind, the champion feat benefit also provides a +2 bonus to MD.
+
+## Deadly Thrust
+
+Melee attack
+
+At-Will
+
+**Target:** One staggered non-mook enemy
+
+**Attack:** Dexterity + Strength + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage.
+
+**Miss:** Damage equal to your level.
+
+### Adventurer Feat
+
+Add your Strength modifier to the miss damage.
+
+### Champion Feat
+
+You can now target mooks with _deadly thrust_.
+
+### Epic Feat
+
+If you don’t add your Sneak Attack damage to the attack, you also deal damage equal to five times your Strength modifier to your deadly thrust target when you hit.
+
+## Flying Blade
+
+Ranged attack
+
+At-Will
+
+**Special:** You must use a small bladed weapon with this attack.
+
+**Target:** One nearby creature
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage, and if your natural attack roll is even and one of your allies is engaged with the target, you can use your Sneak Attack damage for the round.
+
+**Miss:** Damage equal to your level.
+
+### Adventurer Feat
+
+If you score a critical hit with _flying blade_, the target is also dazed (–4 attack) until the end of your next turn.
+
+### Champion Feat
+
+As long as one of your allies is engaged with the target, your _flying blade_ attack rolls no longer need to be even to add your Sneak Attack damage.
+
+### Epic Feat
+
+You can use _flying blade_ with any ranged weapon.
+
+## Roll With It
+
+Momentum power
+
+At-Will (once per round)
+
+Interrupt action; requires momentum
+
+Trigger: A melee attack that targets AC hits you.
+
+**Effect:** You take half damage from that attack.
+
+### Adventurer Feat
+
+The power also triggers on an attack against PD.
+
+### Champion Feat
+
+The power also triggers on a ranged attack.
+
+### Epic Feat
+
+Once per day, you can use roll with it to take damage equal to the attacker’s level instead of half damage.
+
+## Sure Cut
+
+Melee attack
+
+At-Will
+
+**Special:** You must have momentum and be able to deal your Sneak Attack damage to the target if you hit.
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage.
+
+**Miss:** Deal your Sneak Attack damage + damage equal to your level.
+
+### Champion Feat
+
+Missing with _sure cut_ no longer counts as a use of Sneak Attack for the round.
+
+## Tumbling Strike
+
+Melee attack
+
+At-Will
+
+Always: You gain a +5 bonus to all disengage checks you attempt this turn. You can also move to engage an enemy, make this attack against it, and then use a quick action to attempt to disengage from it (the quick action disengage lets you move again if you succeed).
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage.
+
+**Miss:** Damage equal to your level.
+
+## 3rd Level Powers
+
+### Bleeding Strike
+
+Melee attack
+
+At-Will
+
+**Target:** One enemy who is not taking ongoing damage
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** WEAPON + Dexterity damage, and if your natural attack roll was even, the target takes ongoing damage equal to 1d4 times your level.
+
+**Miss:** Damage equal to your level.
+
+#### Adventurer Feat
+
+The ongoing damage against large or huge targets increases to 1d6 times your level.
+
+#### Champion Feat
+
+A natural even miss also deals ongoing damage equal to your level.
+
+#### Epic Feat
+
+You can now use _bleeding strike_ against enemies taking ongoing damage.
+
+### Deflection
+
+Momentum power
+
+At-Will (once per round)
+
+Interrupt action; you must spend your momentum
+
+Trigger: A melee attack misses you.
+
+**Effect:** The attack hits a different enemy you are engaged with instead, but deals only half damage.
+
+#### Adventurer Feat
+
+The power also triggers on a ranged attack against AC.
+
+#### Champion Feat
+
+The deflected attack now deals full damage instead of half damage.
+
+#### Epic Feat
+
+Using _deflection_ no longer spends your momentum.
+
+### Slick Feint
+
+Melee attack
+
+At-Will
+
+**First** **Target:** One enemy engaged with you
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** The target is dazed until the end of your next turn, and you can make an improved attack against a second target.
+
+Miss (First Target): Your attack action is over; the feint was a screw-up.
+
+**Second** **Target:** A different enemy from the first target that is engaged with you
+
+**Attack:** Dexterity + Level +2 vs. AC
+
+**Hit:** WEAPON + Dexterity damage.
+
+Miss (Second Target): Damage equal to your level.
+
+### Thief’s Strike
+
+Note: This is a bonus 3rd-level power for rogues with the Thievery talent. Other rogues can choose it if they like.
+
+Melee attack
+
+At-Will
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. PD
+
+**Hit:** Half of WEAPON + Dexterity damage (including Sneak Attack damage if any), and roll a normal save. If you succeed, you can pickpocket an item from the target that they are not holding. (If you roll 16+, the target doesn’t realize you pickpocketed them.)
+
+**Miss:** —
+
+## 5th Level Powers
+
+### Harmless Misdirection
+
+Momentum power
+
+At-Will (once per round)
+
+Interrupt action; requires momentum
+
+Trigger: You miss with a melee attack while an ally is engaged with the target.
+
+**Effect:** You can pop free from the target, and the target can’t attack you during its next turn as long as your ally remains engaged with it.
+
+### Spiky Bastard
+
+Daily
+
+Quick action
+
+**Effect:** You go all-out to hurt anyone who tries to get a piece of you. For the rest of the battle, while you're conscious, using at least one bladed weapon, and are not staggered or stunned, you deal 10 damage to each enemy that makes a melee attack against you and rolls a natural odd attack roll. The damage hits the enemy before their attack damages you.
+
+#### Champion Feat
+
+_Spiky bastard_ damage now applies when you are staggered, though obviously not while you are unconscious.
+
+#### Epic Feat
+
+If the escalation die is 3+, the damage increases to 15 instead of 10.
+
+### Swift Dodge
+
+Momentum power
+
+At-Will (once per round)
+
+Interrupt action; requires momentum
+
+Trigger: You are hit by an attack against AC.
+
+**Effect:** The attacker must reroll the attack.
+
+#### Champion Feat
+
+The power also triggers on an attack against PD.
+
+#### Epic Feat
+
+The attack reroll takes a –2 penalty.
+
+## 7th Level Powers
+
+### Assassin’s Gambit
+
+Melee attack
+
+At-Will
+
+**Target:** One enemy
+
+**Attack:** Dexterity + Level vs. AC
+
+**Hit:** Half of WEAPON + Dexterity damage (including Sneak Attack damage if any), and if you drop a non-mook target to 0 hp, you can take another standard action this turn.
+
+**Miss:** Damage equal to your level.
+
+#### Epic Feat
+
+Once a turn, you can get the extra standard action when this attack drops a mook target.
+
+### Swift Riposte
+
+Momentum power
+
+At-Will (once per round)
+
+Interrupt action; you must spend your momentum
+
+Trigger: An enemy targets you with a melee attack.
+
+**Effect:** You can make a basic attack against your attacker. If your natural attack roll equals or beats your attacker’s roll, resolve your basic attack against that enemy first. If your attack roll is lower, your attack has no effect, regardless of whether it hits or misses.
+
+**Special:** You can’t gain momentum from hitting with swift riposte.
+
+#### Champion Feat
+
+If your _swift riposte_ attack is a critical hit, the enemy’s attack misses.
+
+#### Epic Feat
+
+You gain a +2 attack bonus with _swift riposte_ attacks.
+
+## 9th Level Powers
+
+### Death’s Twin
+
+Momentum power
+
+At-Will
+
+Standard action on your turn; you must spend your momentum
+
+**Effect:** You can make two basic attacks at any point during your turn, each against a different target. You only regain momentum if your second attack hits.
+
+#### Epic Feat
+
+If your attack against your first _death’s twin_ target is a natural 18+, you can make your second basic attack against that same target.
+
+### True Targeting
+
+Momentum power
+
+At-Will
+
+Interrupt action OR free action on your turn; you must spend your momentum
+
+Trigger: An invisible or otherwise hidden enemy attacks you, or you try to attack an invisible or hidden enemy.
+
+**Effect:** The attacker’s invisibility isn’t going to work on you. It might work against your allies, but you see through it and can tell where the creature is well enough to target it normally or be aware of its imminent attack.
+
+#### Epic Feat
+
+If the enemy’s attack misses, you regain momentum.

--- a/Classes/Sorcerer.md
+++ b/Classes/Sorcerer.md
@@ -1,0 +1,839 @@
+---
+aliases: [Sorcerer]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Sorcerer]
+updated:: 2023-05-07
+---
+
+# Sorcerer
+
+## Ability Scores
+
+Sorcerers gain a +2 class bonus to Charisma or Constitution, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: tribal shaman, pirate captain, spell-arena gladiator, failed wizard, sahuagin hunter.
+
+## Gear
+
+At 1st level, a sorcerer usually has a simple melee weapon, a few changes of clothing, a wand or staff, and other paraphernalia suggested by their backgrounds.
+
+### Gold Pieces
+
+Sorcerers may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 10      | —           |
+| Heavy      | 11      | –2          |
+| Shield     | 1       | -2          |
+
+### Melee Weapons
+
+| 0                | One-Handed             | Two-Handed                |
+|------------------|------------------------|---------------------------|
+| Small            | 1d4 dagger             | 1d6 staff                 |
+| Light or Simple  | 1d6 shortsword         | 1d8 spear                 |
+| Heavy or Martial | 1d8 (-2 atk) longsword | 1d10 (-2 atk) greatsword* |
+
+### Ranged Weapons
+
+| 0                | Thrown      | Crossbow                     | Bow                    |
+|------------------|-------------|------------------------------|------------------------|
+| Small            | 1d4 dagger  | 1d4 hand crossbow            | —                      |
+| Light or Simple  | 1d6 javelin | 1d6 (–1 atk) light crossbow* | 1d6 (-2 atk) shortbow* |
+| Heavy or Martial | —           | 1d8 (–3 atk) heavy crossbow* | 1d8 (-4 atk) longbow*  |
+  
+* A sorcerer needs one free hand to cast spells. As such, they suffer a penalty for using a two-handed weapon. (The penalty applies to spells also.)
+
+## Level Progression
+
+| Sorcerer Level     | Total Hit Points           | Total Feats                    | 1st level spell (M) | 3rd level spell (M) | 5th level spell (M) | 7th level spell (M) | 9th level spell (M) | Level-up Ability Bonuses | Damage Bonus From Ability Score |
+|--------------------|----------------------------|--------------------------------|---------------------|---------------------|---------------------|---------------------|---------------------|--------------------------|---------------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                   | 4                   | —                   | —                   | —                   | —                   | Not affected             | ability modifier                |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   | 4                   | —                   | —                   | —                   | —                   |                          | ability modifier                |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 5                   | —                   | —                   | —                   | —                   |                          | ability modifier                |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 3                   | 3                   | —                   | —                   | —                   |                          | ability modifier                |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | —                   | 6                   | —                   | —                   | —                   | +1 to 3 abilities        | ability modifier                |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        | —                   | 3                   | 4                   | —                   | —                   |                          | 2 x ability modifier            |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | —                   | —                   | 7                   | —                   | —                   |                          | 2 x ability modifier            |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | —                   | —                   | 3                   | 5                   | —                   | +1 to 3 abilities        | 2 x ability modifier            |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | —                   | —                   | —                   | 8                   | —                   |                          | 3 x ability modifier            |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | —                   | —                   | —                   | 3                   | 6                   |                          | 3 x ability modifier            |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | —                   | —                   | —                   | —                   | 9                   | +1 to 3 abilities        | 3 x ability modifier            |
+
+Note: Although not listed on the table, this class gets three talents. It does not gain more at higher levels.
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus             | +2 Charisma or Constitution (different from racial bonus)    |
+|---------------------------|--------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                              |
+| Armor Class (light armor) | 10 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense          | 11 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense            | 10 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                | (6 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                | 8                                                            |
+| Recovery Dice             | (1d6 x Level) + Con mod                                      |
+| Backgrounds               | 8 points, max 5 in any one background                        |
+| Icon Relationships        | 3 points                                                     |
+| Talents                   | 3                                                            |
+| Feats                     | 1 per Level                                                  |
+
+## Basic Attacks
+
+### Melee attack
+
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** Damage equal to your level
+
+### Ranged attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+All sorcerers share three general class features: Access to Wizardry, Dancing Lights, and Gather Power. _Breath weapon_, _chain_, and _random energy_ are keywords used in sorcerer spells
+
+### Access to Wizardry
+
+Starting at 3rd level, you can take a wizard spell in place of a sorcerer spell. The wizard spell must be two levels lower than the sorcerer spell.
+
+### Breath Weapon
+
+Spells with the _breath weapon_ keyword have a chance to be re-used during battle. Each _breath weapon_ spell lists the chance of re-using it (usually 16+). At the start of each round after you’ve cast the _breath weapon_ spell, make the re-use roll. Success indicates that you may re-use that spell as a standard action, but for that round only. If you fail the re-use roll, you don’t have the option to re-use the spell, but you get another chance at the beginning of the next round.
+
+The _breath weapon_ power lasts for a single battle only.
+
+You can have only one _breath weapon_ spell active at a time. If you cast a different _breath weapon_ spell when you have an earlier spell active, the new spell cancels the earlier spell. (See the Chromatic Destroyer Heritage talent for the path to multiple _breath weapon_ spells.)
+
+Failing a death save cancels any _breath weapon_ spells you have active.
+
+#### Adventurer Feat
+
+Failing a death save no longer cancels your _breath weapon_ spells. Keep rolling the entire battle.
+
+### Chain
+
+When you attack with a _chain_ spell and get a natural even roll, you can roll another attack against a different enemy within range. Keep on rolling attacks as long as you get even rolls and don’t run out of new targets. Each enemy can be targeted only once.
+
+### Dancing Lights
+
+All sorcerers can cast the _dancing lights_ spell as a standard action. Unlike the wizard’s _light_ cantrip, the sorcerer’s _dancing lights_ spell produces a number of varicolored light globes that bloom within 5 to 30 feet of the sorcerer every two to five seconds. The sorcerer has very little control over the exact location or illumination provided by the lights, meaning that they can occasionally be used for dramatic plot purposes.
+
+### Gather Power
+
+Once initiative has been rolled and a battle is underway, a sorcerer can spend a standard action to gather magical power, preparing themselves for casting a double-strength spell with their next standard action. Gathering power is loud and very noticeable.
+
+Sorcerers who want to gather power before initiative has been rolled can go through the motions but won’t get any benefit from the act.
+
+When a sorcerer gathers power, it does not count as casting a spell; you can gather power without taking opportunity attacks.
+
+In addition, because you spend your standard action to gather power, you generate a small magical benefit. Like many of your powers, this benefit is chaotic rather than perfectly reliable, so you must make a random check to see what benefit you get. Roll a d6 and consult the appropriate table below.
+
+If you get a benefit that deals damage to enemies, you can choose the type of damage (cold, fire, lightning, or thunder).
+
+#### Chaotic Benefit, Adventurer Tier (levels 1–4)
+
+| Roll (d6) | Effect                                                           |
+| --------- | ---------------------------------------------------------------- |
+| 1-2       | You gain a +1 bonus to AC until the start of your next turn.     |
+| 3-4       | Deal damage equal to your level to all nearby staggered enemies. |
+| 5-6       | Deal damage equal to your level to one nearby enemy.             |
+
+#### Chaotic Benefit, Champion Tier (levels 5–7)
+
+| Roll (d6) | Effect                                                                                    |
+| --------- | ----------------------------------------------------------------------------------------- |
+| 1-2       | You gain a +1 bonus to AC and Physical Defense until the start of your next turn.         |
+| 3-4       | Deal damage equal to your level + your Charisma modifier to all nearby staggered enemies. |
+| 5-6       | Deal damage equal to your level + your Charisma modifier to one nearby enemy.             |
+
+#### Chaotic Benefit, Epic Tier (levels 8–10)
+
+| Roll (d6) | Effect                                                                                          |
+| --------- | ----------------------------------------------------------------------------------------------- |
+| 1-2       | You gain a +1 bonus to all defenses until the start of your next turn.                          |
+| 3-4       | Deal damage equal to your level + twice your Charisma modifier to all nearby staggered enemies. |
+| 5-6       | Deal damage equal to your level + twice your Charisma modifier to one nearby enemy.             |
+
+After you have gathered power, you can use your next standard action to cast an empowered sorcerer spell. Empowered sorcerer spells deal double the damage of a normal sorcerer spell. This means that you double the damage results of the hit or a miss from the single spell. Non-attack spells generally don’t improve when cast empowered; use empowered casting for attacks.
+
+If you do not or are not able to use your next standard action to cast a sorcerer attack spell, you lose the power you’ve gathered. You can use another standard action to gather power again, but the spell you eventually cast will still only do double damage.
+
+You can spend your move actions and quick actions any way you like after you gather power and before casting your next empowered spell. Yes, once a battle has started it’s possible to perform the magical firefight trick of gathering power while hiding to the side of the cave entrance, then jumping into the cave opening on your next turn and blasting with the empowered spell.
+
+Breath weapon spells add an extra wrinkle. Of course you can gather power the first time you cast a breath weapon spell in a battle. Later in the fight it’s a question of whether you gathered power the turn before a breath weapon spell roll goes your way. You can be all ready with gathered power but roll too low to use the breath weapon spell, forcing you to cast a different spell with the gathered power.
+
+If you've gathered power for a spell that deals ongoing damage, the ongoing damage is doubled the first time it is dealt, but not on subsequent rounds, if any.
+
+#### Adventurer Feat
+
+Once per battle, you can choose the chaotic benefit you want instead of rolling for it.
+
+#### Champion Feat
+
+Once per battle when the escalation die is 4+, you can gather power as a quick action.
+
+#### Epic Feat
+
+When you gather power, if the escalation die is 2+, you can roll two chaotic benefits. Unlike most effects, the benefits stack if you roll the same result twice.
+
+### Random Energy
+
+Some sorcerer spells deal damage of a random type. If it matters for the situation, use a d4 to determine which type of damage the spell deals.
+
+| Roll (d4) | Energy Type |
+|-----------|-------------|
+| 1         | Cold        |
+| 2         | Fire        |
+| 3         | Lightning   |
+| 4         | Thunder     |
+
+## Class Talents
+
+### About Heritage Talents
+
+Sorcerers possess innate talent for magic that is impulsive and chaotic where wizardry is measured and studied. Most sorcerers have strong magical links to one of the icons.
+
+### Arcane Heritage
+
+Although magic is in the blood of every sorcerer, you have a greater understanding of magic than most sorcerers and even some wizards.
+
+You gain a +2 bonus to a background that involves or suggests magical knowledge or talent, up to your normal maximum background point limit.
+
+You can also use one of your sorcerer spell choices to choose any wizard spell of the same level. You get only one such equal-level wizard spell at a time; all others have to be purchased using the 2-level penalty in the Access to Wizardry class feature described above.
+
+#### Adventurer Feat
+
+Use your Charisma as the attack ability for the wizard spell you choose with your Arcane Heritage talent.
+
+#### Champion Feat
+
+You can cast your wizard spells empowered as if they were sorcerer powers. Generally, empowering wizard spells only helps by doubling the damage.
+
+### Blood Link
+
+Choose one of your sorcerous heritage talents. You gain 1 relationship point with the icon associated with that heritage; you choose whether the point is positive, conflicted, or negative. This point can add to your normal relationship points but you can’t exceed the normal relationship maximums with it. (Remember that positive relationships with villainous icons are limited to 1 point.)
+
+#### Champion Feat
+
+Gain another relationship point with an icon associated with one of your heritage talents. As above, you must follow the relationship maximums.
+
+### Chromatic Destroyer Heritage
+
+You can have multiple _breath weapon_ spells active at the same time. You don’t gain extra actions, so if you succeed with multiple _breath weapon_ spells, you’ll generally have to choose which one to use.
+
+#### Adventurer Feat
+
+You gain a +2 attack bonus with empowered _breath weapon_ spells.
+
+#### Champion Feat
+
+Once per day, turn a failed _breath weapon_ re-use roll into a success.
+
+#### Epic Feat
+
+One battle per day, gain resist dragon attack 16+ (all attacks made by dragons; dragon must roll natural 16+ with the attack or it deals only half damage).
+
+### Fey Heritage
+
+One battle per day, when you roll initiative, you can choose to invoke your Fey Heritage and gain the racial power of one the elven races in addition to your own racial power. Roll on the table below. If you roll your own race’s power, you gain the half-elf’s _surprising_ racial power instead.
+
+| Roll (d6) | Racial Power                  |
+|-----------|-------------------------------|
+| 1-2n      | Cruel (drow)                  |
+| 3-4n      | Highblood teleport (high elf) |
+| 5-6n      | Elven grace (wood elf)        |
+
+#### Adventurer Feat
+
+You can now invoke your Fey Heritage talent in two battles each day.
+
+#### Champion Feat
+
+You gain a +2 attack bonus against elves and monsters in the elven sphere of influence (including the Drider, Storm Giant, and Medusa).
+
+#### Epic Feat
+
+Once per battle when the escalation die reaches 6+, as a free action, you can gain an elf racial power that you have not already used in this battle.
+
+### Infernal Heritage
+
+Once per day, as a quick action when the escalation die is 1+, you can enter a spell frenzy until the end of the battle.
+
+While in a spell frenzy, you roll 2d20 for each of your sorcerer spell attacks. Use the highest die as your attack roll, but track whether the other die hits.
+
+For each die that misses, you take damage equal to double the level of the target of your attack.
+
+#### Adventurer Feat
+
+You gain resist energy damage 12+ to fire and to one of the following types of energy of your choice: acid, cold, lightning, psychic, thunder.
+
+#### Champion Feat
+
+Increase one of your resistances to 16+.
+
+#### Epic Feat
+
+In addition to your normal use of spell frenzy, you can also enter a spell frenzy as a free action while the escalation die is 5+.
+
+### Metallic Protector Heritage
+
+Your rolls to re-use breath weapon spells during a fight gain a +2 bonus.
+
+#### Adventurer Feat
+
+As a quick action at the start of each battle, you can gain resist energy 12+ to one of the following types of energy of your choice: acid, cold, fire, lightning, or poison.
+
+#### Champion Feat
+
+When you gather power and your chaotic benefit increases your defenses, you can choose one nearby ally to gain the same defense bonus.
+
+#### Epic Feat
+
+One battle per day, you can choose to gain resist demon attack 16+ instead of resist energy 12+ from your Metallic Protector Heritage talent.
+
+### Sorcerer’s Familiar
+
+You have a familiar much like a wizard’s familiar, but more changeable. Unlike the wizard, you don’t choose two abilities for your familiar. Instead you choose one permanent ability that suits your familiar’s nature; the only limitation is that you can’t choose _tough_ as the permanent ability. Each time you get a full heal-up, randomly determine two _other_ abilities your familiar will possess until your next full heal-up.
+
+#### Adventurer Feat
+
+Your familiar gains another randomly changing ability.
+
+#### Champion Feat
+
+Once per level, if your familiar is close to you, it can cast one of your spells as a free action on your initiative count, even if you have already expended the spell. The spell functions as if you had cast it.
+
+#### Epic Feat
+
+Your familiar gains another randomly changing ability.
+
+### Spell Fist
+
+Your style of sorcery emphasizes close-range fighting. There are two advantages and one possible drawback to your style.
+
+You gain a +2 bonus to AC.
+
+You can use ranged spells while engaged with enemies without taking opportunity attacks.
+
+You use your Constitution modifier instead of your Charisma modifier to determine the damage you add to all your sorcerer spells.
+
+#### Adventurer Feat
+
+When you miss with a sorcerer spell against an enemy you are engaged with, add your Charisma modifier to the damage you deal. At 5th level, add double your Charisma modifier; at 8th level, triple it.
+
+#### Champion Feat
+
+Once per battle, you can include one enemy engaged with you as an additional target of any attack spell you cast that targets other enemies.
+
+#### Epic Feat
+
+Once per day when you cast an empowered spell, each enemy engaged with you becomes an additional target of that spell if it’s not already targeted by the spell.
+
+### Undead Remnant Heritage
+
+You have resist negative energy 12+ and gain a +1 attack bonus against undead. You can also include negative energy damage on your personal random energy damage type table, swapping out an energy type you don’t want to access randomly.
+
+#### Adventurer Feat
+
+Decrease your total recoveries by 1; you gain a +2 bonus to death saves.
+
+#### Champion Feat
+
+Your resist negative energy power improves to 16+, and the attack bonus against undead increases to +2.
+
+#### Epic Feat
+
+If you put out one of your eyes and cut off one of your hands, you gain a +1 bonus to all attacks.
+
+## 1st Level Spells
+
+### Breath of the White
+
+Close-quarters spell
+
+Daily
+
+**Target:** 1d2 nearby enemies in a group; breath weapon
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 3d6 + Charisma cold damage.
+
+**Miss:** Half damage.
+
+3rd level spell: 5d6 damage.
+
+5th level spell: 4d10 damage.
+
+7th level spell: 6d12 damage.
+
+9th level spell: 10d12 damage.
+
+_Breath Weapon_: For the rest of the battle, roll a d20 at the start of each of your turns. On a 16+, you can use breath of the white dragon that turn if you wish.
+
+### Burning Hands
+
+Close-quarters spell
+
+At-Will
+
+Targets: Up to two nearby enemies in a group
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d6 + Charisma fire damage.
+
+3rd level spell: 1d8 damage.
+
+5th level spell: 2d8 damage.
+
+7th level spell: 3d8 damage.
+
+9th level spell: 5d8 damage.
+
+#### Adventurer Feat
+
+When you miss with _burning hands_, you deal fire damage to the target equal to each damage die that rolled its maximum possible result.
+
+#### Champion Feat
+
+When you roll a natural 18+ with a _burning hands_ attack roll, you can choose another nearby target for the spell. The new target doesn’t have to be part of the original group.
+
+#### Epic Feat
+
+You can now target each enemy engaged with you with your _burning hands_ spell in addition to any other targets.
+
+### Chaos Bolt
+
+Ranged spell
+
+At-Will
+
+**Special:** The first time you use _chaos bolt_ each battle, determine a random energy type. The spell deals that type of damage each time you use it that battle.
+
+**Target:** Either a single nearby enemy or a single faraway enemy with a –2 attack penalty
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d8 + Charisma random energy damage, and if the natural attack roll was even, you gain a chaotic benefit as if you had gathered power.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d8 damage.
+
+5th level spell: 5d8 damage.
+
+7th level spell: 7d8 damage.
+
+9th level spell: 9d8 damage.
+
+#### Adventurer Feat
+
+You don’t take the –2 penalty for attacking a faraway enemy with the spell.
+
+#### Champion Feat
+
+If you are a champion-tier sorcerer, roll any chaotic benefit gained with this spell on the epic chaotic benefits table. If you are an epic-tier sorcerer, choose the epic chaotic benefit you want instead of rolling.
+
+### Lightning Fork
+
+Ranged spell
+
+Recharge 16+ after battle
+
+**Target:** One nearby enemy; chain spell
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 3d6 + Charisma lightning damage.
+
+**Miss:** Half damage.
+
+3rd level spell: 7d6 damage.
+
+5th level spell: 6d10 damage.
+
+7th level spell: 10d10 damage.
+
+9th level spell: 2d8 x 10 damage.
+
+#### Adventurer Feat
+
+Once per battle, you can reroll one of your _lightning fork_ attacks rolls.
+
+#### Champion Feat
+
+If you miss all targets with _lightning fork_, you don’t expend it.
+
+#### Epic Feat
+
+The recharge roll for _lightning fork_ is now 11+.
+
+_**Chain Spell:**_ Each time you make a natural even attack roll, you can attack a different target with the spell.
+
+### Resist Energy
+
+Ranged spell
+
+Recharge 16+ after battle
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle, the target gains resist damage 12+ to the following energy type of your choice: cold, fire, lightning, thunder.
+
+3rd level spell: Choose two types of energy the target gains resistance to.
+
+5th level spell: Resistance is now 16+.
+
+7th level spell: The spell now affects two targets.
+
+9th level spell: Recharge roll is now 11+.
+
+#### Adventurer Feat
+
+You can target an additional creature with the spell.
+
+### Scorching Ray
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 1d6 + Charisma fire damage, and if the natural attack roll is even, the target also takes 1d8 ongoing fire damage.
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 3d6 damage; 2d4 ongoing.
+
+5th level spell: 4d6 damage; 2d6 ongoing.
+
+7th level spell: 6d6 damage; 3d6 ongoing.
+
+9th level spell: 10d6 damage; 5d6 ongoing.
+
+#### Adventurer Feat
+
+You can now use the spell against a faraway target, but with a –2 attack penalty.
+
+#### Champion Feat
+
+Each time you cast the spell, you can have the attack deal random energy damage instead of fire damage. Replace the fire entry on the random energy table with your choice of negative energy or acid.
+
+#### Epic Feat
+
+You don’t take the –2 penalty for attacking a faraway enemy with the spell.
+
+## 3rd Level Spells
+
+### Breath of the Green
+
+Close-quarters spell
+
+Daily
+
+**Target:** 1d4 nearby enemies in a group; breath weapon
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 15 + Charisma ongoing poison damage.
+
+**Miss:** 5 ongoing poison damage.
+
+5th level spell: 25 + Charisma ongoing poison damage; 10 ongoing on a miss.
+
+7th level spell: 35 + Charisma ongoing poison damage; 15 ongoing on a miss.
+
+9th level spell: 50 + Charisma ongoing poison damage; 25 ongoing on a miss.
+
+_Breath Weapon_: For the rest of the battle, roll a d20 at the start of each of your turns; on a 16+, you can use _breath of the green_ that turn if you wish.
+
+### Chaos Pulse
+
+Ranged spell
+
+At-Will
+
+**Target:** One random nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 3d10 + Charisma random energy damage.
+
+**Even Miss:** Half damage.
+
+**Odd Miss:** Damage equal to your level.
+
+5th level spell: 5d10 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 9d10 damage.
+
+### Dragon’s Leap
+
+Ranged spell
+
+Daily
+
+Quick action to cast
+
+**Target:** You; breath weapon
+
+**Effect:** You can fly at the rate you normally move until the end of your turn. (So if you don’t land or find someplace to hang from, you’ll fall.)
+
+5th level spell: You can now fly until the end of your next turn.
+
+7th level spell: You can now fly twice as fast as you normally move on the ground. You also gain a +5 bonus to disengage checks.
+
+9th level spell: The spell is now recharge 16+ after battle instead of daily.
+
+_Breath Weapon_: For the rest of the battle, roll a d20 at the start of each of your turns; on a 16+, you can use _dragon’s leap_ this turn if you wish. (Yeah, we know it’s not actually a breath weapon, but it works as part of the draconic sorcerer package.)
+
+### Echoing Thunder
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 3d6 + Charisma thunder damage, and the first enemy that hits you with a melee attack before the start of your next turn takes 2d6 thunder damage. (An empowered spell does not double this aftershock damage.)
+
+**Miss:** Damage equal to your level.
+
+5th level spell: 5d6 damage; 2d6 aftershock damage.
+
+7th level spell: 7d6 damage; 3d6 aftershock damage.
+
+9th level spell: 9d6 damage; 4d6 aftershock damage.
+
+#### Champion Feat
+
+The spell’s aftershock damage is now also doubled when echoing thunder is empowered.
+
+## 5th Level Spells
+
+### Breath of the Black
+
+Close-quarters spell
+
+Daily
+
+**Target:** One nearby enemy; breath weapon
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 10d6 + Charisma acid damage, and 20 ongoing acid damage.
+
+**Miss:** 10 ongoing acid damage.
+
+7th level spell: 10d10 damage, and 40 ongoing damage; 20 ongoing on a miss.
+
+9th level spell: 2d6 x 10 damage, and 60 ongoing damage; 30 ongoing on a miss.
+
+#### Epic Feat
+
+Double the spell’s ongoing damage on a miss.
+
+_Breath Weapon_: For the rest of the battle, roll a d20 at the start of each of your turns; on a 16+, you can use _breath of the black_ that turn if you wish.
+
+### The Elven Shadows
+
+Ranged spell
+
+Daily
+
+**Special:** Once you cast this spell in a battle, you can cast it at-will for the rest of that battle.
+
+**Target:** One nearby enemy
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** 8d6 + Charisma psychic damage, and if the natural attack roll is even, you can teleport to a nearby location you can see.
+
+**Miss:** Damage equal to your level.
+
+7th level spell: 9d10 damage.
+
+9th level spell: 10d12 damage.
+
+#### Epic Feat
+
+Once per battle, the teleport from a hit with _the elven shadows_ can be to a faraway location you can see.
+
+### Three Dooms
+
+Ranged spell
+
+Recharge 16+ after battle
+
+**Target:** One nearby enemy; chain spell
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 2d4 x 10 random energy damage, and you take damage of the same type equal to the unmodified dice roll (2d4, 2d8, or 2d12). (Note that there’s no Charisma bonus to damage.)
+
+**Miss:** Half damage, and you still take random energy damage equal to the unmodified dice roll.
+
+7th level spell: 2d8 x 10 damage.
+
+9th level spell: 2d12 x 10 damage.
+
+_**Chain Spell**_**:** Each time you make a natural even attack roll, you can attack a different target with the spell.
+
+### Unearthly Glamour
+
+Ranged spell
+
+Daily
+
+**Effect:** You gain a +5 bonus to all Charisma skill checks for the next five minutes. If you fail a Charisma skill check during this time, however, anyone you were attempting to convince or influence with the check is freaked out or disgusted by the supernatural glamour attached to you and has extremely negative reactions to you.
+
+7th level spell: The effect lasts for 1 hour.
+
+9th level spell: The effect lasts for 2 hours.
+
+## 7th Level Spells
+
+### Breath of the Blue
+
+Close-quarters spell
+
+Daily
+
+**Target:** One nearby enemy; breath spell
+
+**Attack:** Charisma + Level vs. PD
+
+**Hit:** 10d12 + Charisma lightning damage, and at the start of the target’s next turn, 1d6 of its nearby allies take 20 lightning damage.
+
+**Miss:** Half damage, and no damage to target’s allies.
+
+9th level spell: 2d10 x 10 damage; 25 lightning damage to nearby allies.
+
+#### Epic Feat
+
+You can now target a faraway enemy with the spell (no attack penalty).
+
+_**Breath Weapon**_**:** For the rest of the battle, roll a d20 at the start of each of your turns; on a 16+, you can use _breath of the blue_ this turn if you wish.
+
+### Stolen Faces
+
+Ranged spell
+
+Daily
+
+Free action to cast, before initiative is rolled
+
+Targets: 1d4 + 1 nearby allies
+
+**Effect:** You steal the once-per-battle racial powers of your allies this battle, but you don’t get the advantage of your allies’ feats or items that improve those powers.
+
+Each ally you steal a racial power from can roll an easy save (6+). Success means they get to use their power also this battle. Failure means they can’t; you took it fully.
+
+You can’t steal racial powers you already possess.
+
+9th level spell: You get to use your allies’ powers as if you also had any of their feats that improve those powers.
+
+### Touch of Evil
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Special:** If you are fighting one or more demons, roll an easy save (6+) at the start of each of your turns. Failure means that you are confused that turn.
+
+**Target:** You
+
+**Effect:** You gain a random demon-style power for the rest of the battle, similar to the abilities demons possess but not identical.
+
+Roll a d8 to see which power you gain:
+
+| Roll (d8) | Power                              | Description                                                                                                                                                                                                                    |
+|-----------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1         | Resist energy 16+                  | When an attack that deals energy damage targets you, the attacker must roll a natural 16+ on the attack roll or it only deals half damage.                                                                                     |
+| 2         | Infernal battery                   | Until the end of the battle, you can use a quick action once each round to make recharge rolls for your expended recharge spells. Each time you do so, you take damage equal to half the natural result of your recharge roll. |
+| 3         | Backlash                           | The first time you are staggered this battle, the enemy who staggered you becomes confused (save ends).                                                                                                                        |
+| 4         | Spell frenzy                       | You enter a spell frenzy (see Infernal Heritage talent). If you were already in a spell frenzy, you now roll 3d20 for each attack and take damage equal to triple the target’s level for each roll that misses.                |
+| 5         | Fear aura                          | Enemies engaged with you that have fewer hit points than double your current hit points are dazed. They cannot use the escalation die.                                                                                         |
+| 6         | Teleport 1d3 + 1 times this battle | As a move action, you can teleport anywhere you can see nearby.                                                                                                                                                                |
+| 7         | Demonic speed                      | You can take an extra standard action each turn that the escalation die is even. You lose 2d10 hit points each time you use the extra action.                                                                                  |
+| 8         | Eye of the demon                   | Choose any two features you want. For the rest of this day, all your icon relationships disappear and are replaced by an identical number of conflicted points with a villainous icon (preferably one that is demonic).        |
+
+## 9th Level Spells
+
+### Breath of the Void
+
+Close-quarters spell
+
+Daily
+
+**Target:** One nearby enemy; breath spell
+
+**Attack:** Charisma + Level vs. MD
+
+**Hit:** 2d12 x 10 + Charisma negative energy damage, and the target moves down 2d6 points in initiative order, to a minimum of 1.
+
+**Miss:** Half damage.
+
+_Breath Weapon_: For the rest of the battle, roll a d20 at the start of each of your turns; on a 16+, you can use _breath of the void_ this turn if you wish.
+
+### Calling the Blood
+
+Close-quarters spell
+
+Daily
+
+**Effect:** Randomly select an icon (preferably a sorcerous one). You gain some surprising or bizarre magical effect associated with the power of that icon to assist you. The effect is entirely up to the GM, though the immediate impact of the spell should always be favorable for you. The long-term consequences of randomly invoking the power of an icon that may be an enemy might not be favorable for you, and should be played for narrative interest by the GM, particularly if the impact of the spell was huge for you. Since this is a daily spell, sizeable impact is fine, but don’t award any extra effect for empowered casting, especially since the spell can be cast effectively out of combat.
+
+#### Epic Feat
+
+Randomly choose twice, then choose the single result you prefer.
+
+### Silver Flame
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** Roll your relationship dice that you have with a sorcerous heroic icon.
+
+For each 6 you roll, you gain one 7th level or lower spell from any spellcasting class that you can cast this battle. For each 5 you roll, you gain one 5th level or lower spell from any spellcasting class that you can cast this battle.
+
+If the escalation die is 5+, you can swap the escalation die for one or your rolls. If you get no successes, you regain the spell after this battle.
+
+You can acquire one of the new spells the same round you cast this spell. Then select and acquire any other gained spells at the start of your next turn.
+
+You can use your Charisma as the ability score that provides the acquired spells’ attack bonuses and damage bonuses (if any). Other ability score references remain unchanged.
+
+As you might expect, each 5 you roll also invokes an icon-related complication or obligation in the tradition of rolling 5s on relationship checks.

--- a/Classes/Wizard.md
+++ b/Classes/Wizard.md
@@ -1,0 +1,1174 @@
+---
+aliases: [Wizard]
+created: 2023-05-07
+description: 
+image: 
+publish: 
+tags: [13A/Characters/Classes/Wizard]
+updated:: 2023-05-07
+---
+
+# Wizard
+
+## Ability Scores
+
+Wizards gain a +2 class bonus to Intelligence or Wisdom, as long as it isn’t the same ability you increase with your +2 racial bonus.
+
+## Backgrounds
+
+Possible backgrounds include: magical prodigy, spell thief, hedge wizard, transformed familiar, ship’s wizard, royal poisoner.
+
+## Gear
+
+At 1st level, a wizard usually has a dagger, a robe or two, a wand, ritual components in pouches, and other minor accouterments suggested by their backgrounds.
+
+### Gold Pieces
+
+Wizards may start with either 25 gp or 1d6 x 10 gp.
+
+### Armor
+
+| Armor Type | Base AC | Atk Penalty |
+|------------|---------|-------------|
+| None       | 10      | —           |
+| Light      | 10      | —           |
+| Heavy      | 11      | –2          |
+| Shield     | 1       | -2          |
+
+### Melee Weapons
+
+| 0                | One-Handed              | Two-Handed                |
+|------------------|-------------------------|---------------------------|
+| Small            | 1d4 dagger              | 1d6 staff                 |
+| Light or Simple  | 1d6 (-2 atk) shortsword | 1d8 (-2 atk) spear*       |
+| Heavy or Martial | 1d8 (-5 atk) longsword  | 1d10 (-5 atk) greatsword* |
+
+### Ranged Weapons
+
+| 0                | Thrown           | Crossbow                     | Bow                    |
+|------------------|------------------|------------------------------|------------------------|
+| Small            | 1d4 dagger       | 1d4 hand crossbow            | —                      |
+| Light or Simple  | 1d6 (-2) javelin | 1d6 (–1 atk) light crossbow* | 1d6 (-2 atk) shortbow* |
+| Heavy or Martial | —                | 1d8 (–4 atk) heavy crossbow* | 1d8 (-5 atk) longbow*  |
+
+* A wizard needs one free hand on a spellcasting implement to cast spells. As such, they suffer a penalty for using a two-handed weapon. (The penalty applies to spells also.)
+
+## Level Progression
+
+| Wizard Level       | Total Hit Points           | Total Feats                    | 1st level spell (M) | 3rd level spell (M) | 5th level spell (M) | 7th level spell (M) | 9th level spell (M) | Level-up Ability Bonuses |
+|--------------------|----------------------------|--------------------------------|---------------------|---------------------|---------------------|---------------------|---------------------|--------------------------|
+| Level 1 Multiclass | (Avg. of both classes) x 3 | 1 adventurer                   | 5                   | —                   | —                   | —                   | —                   | Not affected             |
+| Level 1            | (6 + CON mod) x 3          | 1 adventurer                   | 5                   | —                   | —                   | —                   | —                   |                          |
+| Level 2            | (6 + CON mod) x 4          | 2 adventurer                   | 6                   | —                   | —                   | —                   | —                   |                          |
+| Level 3            | (6 + CON mod) x 5          | 3 adventurer                   | 3                   | 4                   | —                   | —                   | —                   |                          |
+| Level 4            | (6 + CON mod) x 6          | 4 adventurer                   | 2                   | 6                   | —                   | —                   | —                   | +1 to 3 abilities        |
+| Level 5            | (6 + CON mod) x 8          | 4 adventurer 1 champion        | 1                   | 4                   | 4                   | —                   | —                   |                          |
+| Level 6            | (6 + CON mod) x 10         | 4 adventurer 2 champion        | —                   | 2                   | 8                   | —                   | —                   |                          |
+| Level 7            | (6 + CON mod) x 12         | 4 adventurer 3 champion        | —                   | 1                   | 4                   | 5                   | —                   | +1 to 3 abilities        |
+| Level 8            | (6 + CON mod) x 16         | 4 adventurer 3 champion 1 epic | —                   | —                   | 3                   | 8                   | —                   |                          |
+| Level 9            | (6 + CON mod) x 20         | 4 adventurer 3 champion 2 epic | —                   | —                   | 1                   | 5                   | 6                   |                          |
+| Level 10           | (6 + CON mod) x 24         | 4 adventurer 3 champion 3 epic | —                   | —                   | —                   | 3                   | 9                   | +1 to 3 abilities        |
+
+Note: Although not listed on the table, this class gets three talents. It does not gain more at higher levels.
+
+(M): Indicates columns in which multiclass characters lag one level behind.
+
+## Stats
+
+Initiative, AC, PD, MD, Hit Points, Recovery Dice, Feats, and some Talents are level dependent.
+
+| Ability Bonus             | +2 Intelligence or Wisdom (different from racial bonus)      |
+|---------------------------|--------------------------------------------------------------|
+| Initiative                | Dex mod + Level                                              |
+| Armor Class (light armor) | 10 + middle mod of Con/Dex/Wis + Level                       |
+| Physical Defense          | 10 + middle mod of Str/Con/Dex + Level                       |
+| Mental Defense            | 12 + middle mod of Int/Wis/Cha + Level                       |
+| Hit Points                | (6 + Con mod) x Level modifier (see level progression chart) |
+| Recoveries                | 8                                                            |
+| Recovery Dice             | (1d6 x Level) + Con mod                                      |
+| Backgrounds               | 8 points, max 5 in any one background                        |
+| Icon Relationships        | 3 points                                                     |
+| Talents                   | 3                                                            |
+| Feats                     | 1 per Level                                                  |
+
+## Basic Attacks
+
+### Melee attack
+At-Will
+**Target:** One enemy
+**Attack:** Strength + Level vs. AC
+**Hit:** WEAPON + Strength damage
+**Miss:** —
+
+### Ranged attack
+At-Will
+**Target:** One enemy
+**Attack:** Dexterity + Level vs. AC
+**Hit:** WEAPON + Dexterity damage
+**Miss:** —
+
+## Class Features
+
+Wizards have four class features: Cantrips, Cyclic Spells, Overworld Advantage, and Ritual Magic.
+
+### Cantrips
+
+Every wizard can cast a handful of cantrips each day. You don’t have to memorize or choose them beforehand, you just cast them on the fly.
+
+Wizards can cast a number of cantrips equal to their Intelligence modifier each battle. Each cantrip takes a standard action to cast as a ranged spell. Outside of battle, a wizard can cast about three to six cantrips every five minutes. The Cantrip Mastery talent speeds up cantrip casting.
+
+At the adventurer tier (levels 1–4), cantrips with a standard duration last 10–60 minutes, plus 10 minutes per wizard level. The GM rolls and the wizard becomes aware that their cantrip is about to end a couple minutes before it’s done.
+
+At the champion tier, levels 5–7, most cantrips last 1–6 hours.
+
+At the epic tier, levels 8–10, cantrips last between 2–12 hours.
+
+For a list of available cantrips, see Cantrips.
+
+### Cyclic Spells
+
+Spells that have a cyclic usage can always be cast at least once per battle, and are only expended in that battle if they are cast when the escalation die is 0 or odd. In other words, if you cast a cyclic spell like color spray or rebuke when the escalation die is even, the spell is not expended and can still be cast later in the battle.
+
+### Overworld Advantage
+
+Wizardly magic taps into the power of the overworld. While a wizard is in the overworld, their daily spells become recharge 16+ after battle.
+
+### Ritual Magic
+
+Wizards can cast their spells as rituals.
+
+#### Champion Feat
+
+You can cast full rituals by using all your actions each round to focus on the ritual for 1d3 + 1 rounds. As with standard rituals, your fast rituals are not meant to replace combat spells; they’re a means of acquiring and improvising wondrous magical effects rather than a means of inflicting damage and conditions.
+
+## Class Talents
+
+Choose three of the following class talents.
+
+### Abjuration
+
+Whenever you cast a daily wizard spell, you gain a +4 AC bonus until the end of your next turn.
+
+#### Adventurer Feat
+
+The bonus also applies to your Physical Defense.
+
+#### Champion Feat
+
+You gain 2d12 temporary hit points each time you cast a daily spell.
+
+#### Epic Feat
+
+The bonus also applies to Mental Defense.
+
+### Cantrip Mastery
+
+Cantrips are at-will spells for you.
+
+Unlike normal wizards, who use a standard action to cast a cantrip, you can cast a cantrip as a quick action.
+
+To do something particularly cunning or surprising with one of your cantrips where the GM isn’t sure whether you could pull off that use of the spell, roll a normal save (11+) to cast the spell the way you envision it.
+
+Additionally, you can expend a 3rd level spell slot or higher to choose one cantrip per spell slot you have given up and create a once-per-day related effect with it that is much greater, if you and your GM can agree on a cool effect that suits the cantrip.
+
+#### Adventurer Feat
+
+You can use cantrip-style versions of any wizard spell you have memorized. When you expend a spell, however, you can’t make cantrip-style use of it any more. The key is that none of these uses should be combat relevant or deal damage.
+
+The Cantrip Mastery talent is more about enhance the roleplaying and less about combat usefulness.
+
+### Evocation
+
+Once per battle, when you cast a spell that targets Physical Defense, before rolling for the number of targets or making the spell’s attack roll, you can expend your quick action to evoke the spell. Hit or miss, you'll max out the spell’s damage dice (except on a natural one, which deals no damage to the target and likely damages the caster in some manner).
+
+#### Champion Feat
+
+Whenever you evoke a spell, you can reroll one of the attack rolls if that natural roll was less than or equal to the escalation die. You must take the new result.
+
+### High Arcana
+
+Your study of the highest orders of magic gives you options that lesser wizards cannot match: Memorization and a bonus spell: counter-magic
+
+#### Memorization
+
+When you pick your spells, you can choose any daily wizard spell twice (instead of once). This doesn’t apply to spells that start as recharge spells. For example, at 7th level when you have five 7th level spells and four 5th level spells, you could choose fireball twice as a 7th level spell, or once as a 7th level spell and once as a 5th level spell. (Your 3rd level spell slot can’t be used for fireball because fireball starts as a 5th level spell.)
+
+#### Counter-magic
+
+Close-quarters spell
+
+Once per battle
+
+Free action to cast
+
+Trigger: A nearby creature you can see casts a spell.
+
+**Target:** The nearby creature casting a spell.
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target’s spell is canceled, and the caster loses the action they were using for the spell. If the spell had a limited use, that use is expended if your natural attack roll is even.
+
+#### Champion Feat
+
+You can now cast _counter-magic_ twice per battle.
+
+#### Epic Feat
+
+You can now cast _counter-magic_ in reaction to a creature using any magical ability, not just casting a spell.
+
+### Polysyllabic Verbalizations
+
+Rename each of your daily and recharge spells. Think up the most over-the-top and extravagant names you can muster. Since these alternate spells are so lengthy, they take an additional quick action to cast. While the regular effects of the spells are the same as the more common versions, they have a small bonus effect appropriate to the situation.
+
+The bonus effect is determined by the GM, or by a collaboration between the GM and the player. It should add to the storytelling power of the situation.
+
+The bonus effect should suit the name of the spell or the way it’s delivered, and shouldn’t precisely match up with what the spell normally accomplishes.
+
+### Wizard’s Familiar
+
+Your familiar is a tiny or small animal or creature that aids your magic and provides companionship. It also provides opportunities for improvisation between you and the GM.
+
+Your familiar is as intelligent as a normal person. It can communicate with you and will stay close you unless you’ve chosen abilities that let it roam. Your familiar is on your side but it’s not perfectly in your control.
+
+If your familiar dies, it can come back to you the next time you get a full heal-up. (The method or story used is between you and the GM.) Alternatively, you can get a new familiar.
+
+Familiars are useless in combat, except as indicated by their abilities. Ordinarily they aren’t damaged by enemy attacks and spells unless the story calls for it.
+
+#### Familiar Abilities
+
+Choose two of the following abilities for your familiar.
+
+##### Agile
+
+You gain a +2 bonus to Dexterity skill checks.
+
+##### Alert, Maybe Even Insightful
+
+You gain a +2 bonus to Wisdom skill checks.
+
+##### Counter-bite
+
+Each battle, if your familiar is close to you, it bites the first enemy that hits you with a melee attack after that attack, dealing 1d4 damage per level (no attack roll) to that enemy.
+
+##### Flight
+
+Your familiar flies as well as a hawk. It doesn’t fly that often and usually sticks with you, but it can do so when its other abilities allow.
+
+##### Mimic
+
+One battle per day, you gain the use of the racial power (without feats) of one nearby ally.
+
+##### Poisonous
+
+Once per battle, when you hit an enemy engaged with you, you can add 5 ongoing poison damage per tier to the damage roll.
+
+##### Scout
+
+Once per day, your familiar can separate itself from you and make a reconnaissance run of an area or location. Roll an easy skill check for the environment to get your familiar to scout unseen.
+
+##### Tough
+
+You gain a +1 save bonus. Tough counts as two familiar abilities.
+
+##### Talkative
+
+Your familiar can talk like a person (but the GM speaks for the familiar more than you do).
+
+#### Feat Tiers
+
+##### Adventurer Feat
+
+Your familiar gains another ability.
+
+##### Champion Feat
+
+Once per level, if your familiar is close to you, it can cast one of your spells as a free action on your initiative count, even if you have already expended the spell. The spell functions as if you had cast it.
+
+##### Epic Feat
+
+Your familiar gains another ability.
+
+## Cantrips
+
+### Alarm (standard duration)
+
+The cantrip creates a minor watch-sprite that can be instructed to scream if someone comes through an area or touches an object. Watch-sprites are notoriously stupid and sleepy, but with the right talking-to they might stay focused for the duration of the spell. At higher levels, the spell might summon little fanged spirits buzzing back and forth serving as both visual and actual deterrents.
+
+### Arcane Mark (standard duration)
+
+The cantrip creates a magical sigil on an object or person. These sigils are usually plain to see, though a deliberately invisible mark can be made. It takes a difficult perception or magic check to notice.
+
+### Ghost Sound
+
+This spell creates false noises emanating from somewhere nearby. The effect is like an exceptionally good version of throwing your voice, if your voice could create a wide variety of sounds. Attempted distractions with the cantrip are DC 15 challenges in adventurer environments, higher as you move into champion and epic environments. If someone is using ghost sound against the PCs, a Wisdom-based skill check can identify the sound as a magical fake.
+
+### Knock
+
+This cantrip summons a magical servitor three to four times as big as your closed fist that swarms around the door and attempts to punch or push it open (depending on whether you want to be quiet or announce your presence). Success is determined with an Intelligence check against the environment’s DC using an appropriate magical background. This cantrip does nothing to avoid any traps that might exist.
+
+### Light (standard duration)
+
+This cantrip creates a fairly wide and consistent field of light, up to 30 feet in diameter, though it isn’t bright enough to dazzle.
+
+### Mage Hand
+
+This cantrip creates a small telekinetic effect that lasts a round at most. At best it’s about half as strong as the wizard’s own strongest hand. At worst it’s half as strong as the wizard when they’re weak from a bad fever.
+
+### Mending
+
+This cantrip summons a variety of tiny (hand-sized and smaller) magical sprites who swarm over a chosen broken object attempting to mend it (over the course of 1–6 rounds). Small-scale repairs like torn wineskins, muddy clothing, a broken handgrip on a sword, and similar repairs that anyone could fix with two to four hours of devoted work gets handled in seconds. More elaborate repairs to complicated objects might require an Intelligence check, or at the GM’s discretion could only be possible if the wizard has taken the Cantrip Mastery talent.
+
+### Prestidigitation
+
+This cantrip produces magic tricks and small illusions. One casting usually gives you a minute of fun. The magic has nowhere near as much real world force as mage hand.
+
+### Spark
+
+This is a minor fire creation spell, enough to light a pipe, or a campfire, or even a page or two of an unprotected spellbook. It doesn’t work against living beings or against things that couldn’t easily be set on fire with a few seconds of steady application of a candle. The target of the spark has to be nearby and in sight.
+
+## Utility Spell
+
+When you choose spells during a full heal-up, instead of taking a standard spell, you can choose to give up a spell slot to memorize the _utility spell_ at the same level. When you take the _utility spell_, you gain access to a range of useful non-combat spells of the level you memorized it or below. You cast each _utility spell_ at the level of the spell slot you gave up for it. You can give up multiple spell slots to take _utility spell_ multiple times.
+
+Choose from among the following utility spells:
+
+| Spell Level | Spell           |
+|-------------|-----------------|
+| 1st level   | disguise self   |
+| 1st level   | feather fall    |
+| 1st level   | hold portal     |
+| 3rd level   | levitate        |
+| 3rd level   | message         |
+| 3rd level   | speak with item |
+| 5th level   | water breathing |
+| 7th level   | scrying         |
+
+### Feat Tiers
+
+#### Adventurer Feat
+
+Each _utility spell_ you take lets you cast two spells from the available options instead of one.
+
+#### Champion Feat
+
+As above, but you can cast three _utility spells_ instead of one.
+
+### 1st Level Utility: Disguise Self
+
+Close-quarters spell
+
+Daily
+
+**Effect:** This spell provides you with an effective magical disguise that lasts about ten minutes, making the skill check to avoid unmasking one step easier: easy if it would have been a normal task, normal if it would have been a hard task, and hard if it would have been a ridiculously hard task. The spell only affects your general appearance, not your size. It can be used to hide your features behind the generic features of another person or race. Using it to impersonate a specific creature makes it less effective as a disguise (-2 to -5 penalty).
+
+3rd level spell: The spell lasts for 1 hour.
+
+5th level spell: The spell also provides smell; +2 bonus to any checks.
+
+7th level spell: The spell also handles correct-sounding vocal patterns and rough mannerisms; +4 bonus to any checks.
+
+9th level spell: You can now target an ally with the spell; you can also now use it on up to two creatures at once.
+
+### 1st Level Utility: Feather Fall
+
+Close-quarters spell
+
+Daily
+
+Free action to cast
+
+**Effect:** When you cast this spell, it arrests your fall, letting you glide down the ground over a round or two.
+
+3rd level spell: You can now target a nearby ally with the spell.
+
+5th level spell: You can now target up to two nearby creatures with the spell.
+
+7th level spell: You can now target up to five nearby creatures with the spell.
+
+9th level spell: You gain some control over where a target falls, like a quickly gliding feather.
+
+### 1st Level Utility: Hold Portal
+
+Ranged spell
+
+Daily
+
+**Effect:** You cast this spell on a door. For ten minutes, adventurer-tier creatures can’t get through the door. Champion-tier creatures can batter it down; each attempt requires a DC 20 Intelligence skill check (including an applicable background) by the caster to resist the battering and keep the spell going. Epic-tier creatures can walk right through.
+
+3rd level spell: The spell now lasts for an hour. Adventurer-tier creatures are stymied. Champion-tier creatures can batter the door down or destroy it after three failed DC 20 skill checks by the spellcaster. Epic creatures notice that the now-busted door had magic on it.
+
+5th level spell: Champion-tier creatures take a few minutes to force the door open. Epic creatures can force it open after one failed DC 25 skill check by the spellcaster.
+
+7th level spell: Champion-tier creatures are stymied for up to an hour by the door. Epic tier creatures get through after three failed DC 25 skill checks by the spellcaster.
+
+9th level spell: Champion-tier creatures can’t enter. Epic-tier creatures can’t get through for an hour.
+
+### 3rd Level Utility: Levitate
+
+Ranged spell
+
+Daily
+
+**Effect:** Until the end of the battle, you can use a move action to rise straight up into the air or descend straight down. The spell itself won’t move you horizontally. The up-or-down movement is about half as fast as your normal movement. While levitating, you take a –2 penalty to your attacks and are vulnerable to attacks against you.
+
+5th level spell: You can now cast the spell on a nearby willing ally instead of yourself.
+
+7th level spell: You can now cast the spell as a quick action, and the spell can now affect two targets.
+
+9th level spell: The spell can now affect five targets.
+
+### 3rd Level Utility: Message
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You send a one to two sentence message to another person you know and have touched in the last week. Sending a message to a person you can see is always easy. Sending a message to a person you can’t see requires a skill check using Intelligence against the highest-tier environment that you or the sender are occupying.
+
+The maximum distance you can send a message depends on the spell’s level.
+
+3rd level spell: Across half a city, at most.
+
+5th level spell: Across the entire city and a bit into the countryside.
+
+7th level spell: Between cities near to each other.
+
+9th level spell: From any city to any other city, or across a sea.
+
+### 3rd Level Utility: Speak with Item
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** Speak briefly, mind-to-mind, with a magic item you are touching that is owned by you or one of your allies. The item’s owner gets a free power recharge roll if that item’s power has been expended.
+
+5th level spell: You no longer need to be touching the item; it only has to be nearby.
+
+7th level spell: The item’s owner gains a +2 bonus to the item recharge roll.
+
+9th level spell: If the item recharge roll fails, you keep this spell, but the item won’t talk to you until after your next full heal-up.
+
+### 5th Level Utility: Water Breathing
+
+Close-quarters spell
+
+Daily
+
+Quick action to cast
+
+**Effect:** You can breathe underwater for the rest of the battle (or about five minutes). You become aware a couple of rounds ahead of when the magic of the spell is about to end.
+
+7th level spell: You and 1d4 + 2 nearby allies can breathe underwater this battle.
+
+9th level spell: The spell affects you and 1d6 + 2 nearby allies for 4d6 hours.
+
+### 7th Level Utility: Scrying
+
+Ranged spell
+
+Daily
+
+**Effect:** You can use this spell to get information you shouldn’t be able to get, peering in on other people’s lives for a short period of time, usually no more than ten minutes at a time. Some areas may be warded at the GM’s discretion. You must have touched the person you wish to spy on in the last month, or, at 9th level, within the last a year.
+
+Scrying as a single standard action won’t yield much. Concentrating on the spell for a while with props like a scrying pool or a crystal ball will work better.
+
+## 1st Level Spells
+
+### Acid Arrow
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby or faraway creature
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d10 acid damage, and 5 ongoing acid damage.
+
+**Miss:** 5 ongoing acid damage, and you regain the spell during your next quick rest.
+
+3rd level spell: 5d10 damage, and 10 ongoing damage; 10 ongoing on a miss.
+
+5th level spell: 8d10 damage, and 15 ongoing damage; 15 ongoing on a miss.
+
+7th level spell: 3d4 x 10 damage, and 25 ongoing damage; 25 ongoing on a miss.
+
+9th level spell: 5d4 x 10 damage, and 40 ongoing damage; 40 ongoing on a miss.
+
+### Blur
+
+Ranged spell
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** For the rest of the battle (or for five minutes), attacks against the target miss 20% of the time.
+
+3rd level spell: The spell is now a quick action to cast.
+
+5th level spell: Miss 25% of the time.
+
+7th level spell: Miss 30% of the time, and you can now target 1d2 creatures with the spell.
+
+9th level spell: Miss 30% of the time, and you can now target two creatures with the spell.
+
+### Charm Person
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby creature with 40 hp or fewer
+
+**Special:** This spell cannot be cast during combat or on a target that has rolled initiative to fight.
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target believes you are their friend until you or your allies take hostile action against them. (Attacking their normal allies is okay.) If you or your allies attack the target or order the target to attack its normal allies, the target can roll a normal save to break the charm effect during its turn each round.
+
+**Special:** On a miss, the spell is not detectible by most others unless you miss by 4+ or roll a natural 1, in which case the target and its allies knows what you tried to do and will usually be angry about it.
+
+3rd level spell: Target with 64 hp or fewer.
+
+5th level spell: Target with 96 hp or fewer.
+
+7th level spell: Target with 160 hp or fewer.
+
+9th level spell: Target with 266 hp or fewer.
+
+### Color Spray
+
+Close-quarters spell
+
+Cyclic (cast once per battle OR at-will when the escalation die is even)
+
+**Target:** 1d4 nearby enemies in a group
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 2d8 psychic damage, and if the target has 10 hp or fewer after the damage, it is weakened until the end of your next turn.
+
+3rd level spell: 4d6 damage, 20 hp or fewer.
+
+5th level spell: 6d8 damage, 30 hp or fewer.
+
+7th level spell: 10d6 damage, 40 hp or fewer.
+
+9th level spell: 10d12 damage, 60 hp or fewer.
+
+#### Adventurer Feat
+
+Increase the hit point threshold of the weakened effect by 5 hp.
+
+#### Champion Feat
+
+On a miss, the spell deals damage equal to your level.
+
+#### Epic Feat
+
+The spell now targets 1d4 + 1 nearby enemies in a group.
+
+### Magic Missile
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby or faraway enemy.
+
+**Attack:** Automatic hit
+
+**Effect:** 2d4 force damage.
+
+3rd level spell: 2d8 damage.
+
+5th level spell: 4d6 damage.
+
+7th level spell: 6d6 damage.
+
+9th level spell: 10d6 damage.
+
+#### Adventurer Feat
+
+You can choose two targets; roll half the damage dice for one missile and half the damage dice for the other, then assign one set of damage dice to each of the two targets.
+
+#### Champion Feat
+
+Roll a d20 when you use the spell; if you roll a natural 20, the magic missile crits and deals double damage. (Rolling a 1 is not a fumble; this roll checks only to see if you can crit.)
+
+#### Epic Feat
+
+The 7th and 9th level versions of the spell now use d8s as damage dice.
+
+### Ray of Frost
+
+Ranged spell
+
+At-Will
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 3d6 cold damage
+
+**Miss:** Damage equal to your level.
+
+3rd level spell: 4d8 damage.
+
+5th level spell: 6d8 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 10d12 damage.
+
+#### Adventurer Feat
+
+When your _ray of frost_ attack roll is a natural even hit, if the target is staggered after taking the damage, it is also dazed until the end of your next turn.
+
+#### Champion Feat
+
+The target of the spell can also be faraway.
+
+#### Epic Feat
+
+When you cast the spell you can change the damage type to lightning or negative energy.
+
+### Shield
+
+Close-quarters spell
+
+Recharge 11+ after battle
+
+Free action to cast, when an attack hits your AC.
+
+**Effect:** The attacker must reroll the attack. You must accept the new result.
+
+3rd level spell: You gain a +2 AC bonus against the rerolled attack.
+
+5th level spell: You can also use the spell against attacks that target your Physical Defense; replace references to AC with PD.
+
+7th level spell: The bonus to AC/PD on the rerolled attack increases to +4.
+
+9th level spell: The bonus to AC/PD on the rerolled attack increases to +6.
+
+#### Adventurer Feat
+
+You can now choose either of the attack rolls, in case the second one crits or is otherwise bad for you.
+
+#### Champion Feat
+
+Recharge roll after battle is now 6+.
+
+#### Epic Feat
+
+Hit or miss, you take only half damage from any attack you use shield against.
+
+### Shocking Grasp
+
+Close-quarters spell
+
+At-Will
+
+**Target:** One creature engaged with you
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 1d4 lightning damage, and the target pops free from you.
+
+**Miss:** You take damage equal to the target’s level from botched feedback.
+
+3rd level spell: 1d6 damage.
+
+5th level spell: 2d6 damage.
+
+7th level spell: 3d6 damage.
+
+9th level spell: 4d6 damage.
+
+#### Adventurer Feat
+
+The spell now requires only a quick action to cast (once per round).
+
+#### Champion Feat
+
+Once per battle, when you hit the target of the spell, you can also daze it until the end of your next turn.
+
+#### Epic Feat
+
+The damage dice of the spell increase to d8s.
+
+## 3rd Level Spells
+
+### Confusion
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy with 100 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target is confused (save ends).
+
+**Miss:** If you miss all targets, you regain this spell during your next quick rest.
+
+5th level spell: Target with 160 hp or fewer, and the target can be faraway.
+
+7th level spell: Target with 250 hp or fewer, or two targets each with 125 hp or fewer.
+
+9th level spell: Target with 500 hp or fewer, or two targets each with 250 hp or fewer.
+
+#### Adventurer Feat
+
+On a miss against all targets with this spell, you can choose to daze those targets (save ends). If you do, you do not regain the spell.
+
+#### Champion Feat
+
+Each failed save against the spell deals 6d10 psychic damage to the target.
+
+#### Epic Feat
+
+The save against confused is now a difficult save (16+).
+
+### Crescendo
+
+Close-quarters spell
+
+At-Will
+
+**Target:** One or more enemies engaged with you (but see below)
+
+**Special:** You can choose more than one target for this spell, but you take a –2 penalty when attacking two targets, a –3 penalty for three targets, and so on.
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d6 thunder damage, and the target pops free from you.
+
+**Miss:** Damage equal to your level.
+
+5th level spell: 4d12 damage.
+
+7th level spell: 7d10 damage.
+
+9th level spell: 10d12 damage.
+
+### Force Salvo
+
+Ranged spell
+
+Daily
+
+Targets: One or more nearby or faraway enemies (see below)
+
+**Special:** The spell creates a number of force bolts equal to 1 + your Intelligence modifier. You must target a different creature with each bolt; any extras can’t be used.
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d10 force damage.
+
+5th level spell: 7d10 damage.
+
+7th level spell: 10d12 damage.
+
+9th level spell: 3d6 x 10 damage.
+
+#### Adventurer Feat
+
+You can now target a specific creature with more than one bolt. Once you hit that target, you must target a different creature, and so on. (Roll your attack after each bolt before picking a target for the next bolt.)
+
+#### Champion Feat
+
+On a miss, a bolt now deals miss damage equal to your level.
+
+#### Epic Feat
+
+Increase the number of bolts by 1.
+
+### Hold Monster
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy with 60 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target cannot move or use move actions (hard save ends, 16+).
+
+**Miss:** The target is dazed until the end of your next turn.
+
+5th level spell: Target with 100 hp or fewer.
+
+7th level spell: Target with 160 hp or fewer.
+
+9th level spell: Target with 250 hp or fewer.
+
+#### Adventurer Feat
+
+If the spell misses all targets, you regain the spell during your next quick rest.
+
+#### Champion Feat
+
+The spell can target up to 2 nearby enemies whose total hit points don’t exceed the limit.
+
+#### Epic Feat
+
+Increase the limit by +50 hp.
+
+### Lightning Bolt
+
+Close-quarters spell
+
+Daily
+
+Targets: 1d3 + 1 nearby enemies in a group or in a (rough) line
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 7d8 lightning damage.
+
+**Miss:** Half damage.
+
+5th level spell: 10d10 damage.
+
+7th level spell: 2d8 x 10 damage.
+
+9th level spell: 3d8 x 10 damage.
+
+#### Champion Feat
+
+A natural even hit also deals 10 ongoing lightning damage.
+
+#### Epic Feat
+
+A natural even hit now deals 20 ongoing lightning damage (hard save ends, 16+).
+
+### Rebuke
+
+Ranged spell
+
+Cyclic (once per battle OR at-will when the escalation die is even)
+
+**Target:** One nearby enemy with 100 hp or fewer
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target is hampered (only makes basic attacks) until the end of your next turn.
+
+5th level spell: Target with 160 hp or fewer.
+
+7th level spell: Target with 266 hp or fewer.
+
+9th level spell: Target with 400 hp or fewer.
+
+#### Adventurer Feat
+
+When you roll a natural even hit with the spell, you also deal psychic damage equal to double your level to the target.
+
+#### Champion Feat
+
+When you hit the target with the spell, you also daze it until the end of your next turn.
+
+#### Epic Feat
+
+When you roll a natural even miss against the target, you daze it until the end of your next turn.
+
+### Sleep
+
+Ranged spell
+
+Daily
+
+**Target:** Before making the attack, roll 3d20 + 45 to determine the maximum number of hit points of enemies you can target with the spell. The spell can affect multiple enemies. You must target nearby enemies with the current lowest hit points first, and you don’t get to choose the exact targets (except in the case of ties). If adding a creature would exceed the spell’s hit point maximum, that enemy can’t be a target.
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** The target falls unconscious (hard save ends, 16+; it also ends if the target takes 10+ damage).
+
+**Miss:** The target is dazed until the end of your next turn.
+
+5th level spell: Targets 5d20 +50 max hp.
+
+7th level spell: Targets 7d20 + 100 max hp.
+
+9th level spell: Targets 9d20 + 200 max hp.
+
+### Teleport Shield
+
+Close-quarters spell
+
+Daily
+
+Always: For the rest of the battle, once per round when an enemy moves to engage you, you can make the following attack against it as a free action before it has the chance to attack in melee.
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** Teleport the enemy somewhere nearby you can see. You can place them in combat with one of your allies, but you can’t place them in a dangerous location. (It’s a defensive tool).
+
+5th level spell: The teleported enemy also takes 4d10 damage.
+
+7th level spell: 6d10 damage.
+
+9th level spell: 10d10 damage.
+
+#### Champion Feat
+
+When your _teleport shield_ attack misses, the spell’s attack is not expended that round.
+
+#### Epic Feat
+
+You can now teleport the enemy somewhere faraway that you can see; other restrictions still apply.
+
+## 5th Level Spells
+
+### Denial
+
+Ranged spell
+
+Daily
+
+**Target:** 1d4 nearby enemies in a group
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 9d10 psychic damage, and the target is hampered until the end of your next turn.
+
+**Miss:** Half damage.
+
+7th level spell: 3d4 x 10 damage.
+
+9th level spell: 3d6 x 10 damage.
+
+#### Champion Feat
+
+When you roll a natural even miss with the spell, the target is also hampered until the end of your next turn.
+
+#### Epic Feat
+
+Increase the number of targets to 1d4 + 1.
+
+### Dimension Door
+
+Close-quarters spell
+
+Move action to cast
+
+Daily
+
+**Target:** You
+
+**Effect:** You teleport somewhere nearby that you can see.
+
+7th level spell: Your destination can now be faraway, but not so far that it is out of range of enemy attacks that can hit faraway targets.
+
+9th level spell: You can take one ally who is next to you along with you as you teleport.
+
+### Fireball
+
+Ranged spell
+
+Daily
+
+**Special:** When you cast this spell, you can choose to cast it recklessly.
+
+**Target:** 1d3 nearby enemies in a group. If you cast recklessly, you can target 1d3 additional enemies, but then your allies engaged with the target may also take damage (see below).
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 10d10 fire damage.
+
+**Miss:** Half damage.
+
+Reckless miss: Your allies engaged with the target take one-fourth damage.
+
+7th level spell: 12d10 damage.
+
+9th level spell: 20d10 damage.
+
+#### Champion Feat
+
+Casting the spell recklessly increases the number of additional targets to 1d4 instead of 1d3.
+
+#### Epic Feat
+
+Increase the number of targets to 1d3 + 1 instead of 1d3.
+
+### Invisibility
+
+Ranged spell
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** Until the end of the battle (or for five minutes out of combat), the target becomes invisible until it attacks or uses some ridiculously flashy action.
+
+High Arcana: The duration out of combat is 1 hour instead.
+
+7th level spell: You can now target 1d3 nearby allies (including you) with the spell.
+
+9th level spell: Creatures made invisible by the spell have a 25% chance of remaining invisible the first time (and first time only) they attack or get flashy.
+
+## 7th Level Spells
+
+### Blink
+
+Close-quarters spell
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** For the rest of the battle (or for five minutes), the target gains resist damage 16+. Enemies who can see invisible creatures ignore this resistance.
+
+Whenever the target uses a move action, there is a 50% chance that it can teleport somewhere nearby instead of physically moving.
+
+9th level spell: 75% chance.
+
+### Flight
+
+Ranged spell
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** The target can fly until the end of the battle (or for five minutes). Your speed doesn’t increase appreciably but you can move in three-dimensions.
+
+9th level spell: When you cast the spell, you can choose one: the effect lasts for an hour OR you can target 1d4 + 1 creatures for the normal duration.
+
+### Haste
+
+Ranged spell
+
+Daily
+
+**Target:** You or one nearby ally
+
+**Effect:** On the target’s next turn (not this one, if you cast it on yourself), the target gains an additional standard action.
+
+In addition, at the start of each of the target’s turns this battle, if the escalation die is even, roll a d20 and add the escalation die; on a 16+, the target gains an additional standard action that turn.
+
+9th level spell: The roll for additional standard actions is now 11+ instead of 16+.
+
+  
+  
+
+### Invisibility Purge
+
+Ranged spell
+
+Daily
+
+Targets: Any nearby enemies who are invisible, whether you know they are there or not
+
+**Attack:** Intelligence + Level vs. MD, rolled by GM
+
+**Hit:** The target turns visible and cannot become invisible again this battle.
+
+**Miss:** If there are one or more invisible creatures nearby, you become aware of their presence. Not where they are, or who they are, but that there are invisible creatures present.
+
+9th level spell: The spell also affects faraway targets that you could normally see.
+
+### Overcome Resistance
+
+Ranged spell
+
+Recharge 16+ after battle
+
+**Target:** 1d3 nearby allies (including yourself, if you wish)
+
+**Effect:** Until the end of the battle, the target ignores the resistance power of any creature it targets with an attack.
+
+9th level spell: You can now target 1d4 nearby allies with the spell.
+
+### Transfer Enchantment
+
+Ranged spell
+
+Daily
+
+**Special:** You or an ally you are next to must be suffering from a condition caused by an enemy for you to cast this spell.
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. MD
+
+**Hit:** 2d6 x 10 psychic damage, and you can transfer one condition caused by your enemies from you or the ally you are next to over to the target. If timing is required, interpret the transferred condition as if you had caused it with this spell.
+
+**Miss:** Half damage.
+
+9th level spell: 2d10 x 10 damage; if the spell misses, you regain it during your next quick rest.
+
+## 9th Level Spells
+
+### Disintegrate
+
+Ranged spell
+
+Daily
+
+**Target:** One nearby enemy
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d8 x 10 damage, and the target is vulnerable (hard save ends, 16+).
+
+In addition, if the target drops to 0 hp from this attack, or drops to 0 hp before it saves against the vulnerable effect of this attack, it is gone, dusted, nothing remaining.
+
+**Miss:** Half damage.
+
+#### Epic Feat
+
+You can now target a faraway creature with the spell.
+
+### Meteor Swarm
+
+Ranged spell
+
+Daily
+
+**Special:** You summon a meteor swarm. If you’re underground, you get the ur-dark stalactite equivalent! Nothing more happens this round, but roll 1d3 + 1 to determine how many meteors you have summoned.
+
+At the start of your next turn, even if you are unconscious or dead or have left the area, the meteors arrive one per turn at the start of each of your turns and slam into the combat area.
+
+**Target:** You can make an attack with each meteor against 1d4 enemies in a group. Alternatively, use the spell to level an area with high impact property damage.
+
+**Attack:** Intelligence + Level vs. PD
+
+**Hit:** 4d4 x 10 damage of the energy type of your choice (cold, fire, lightning).
+
+Any allies engaged with the enemies you are targeting take one-fourth damage from each meteor that impacts the area.
+
+**Miss:** Half damage.
+
+#### Epic Feat
+
+Each meteor now deals 5d4 x 10 damage.
+
+### Teleport
+
+Ranged spell
+
+Daily
+
+**Effect:** You and up to 4 allies next to you can teleport to any location in the world, underworld, or overworld that you have previously visited.
+
+When you teleport, roll a d20. If you roll a 1, you miss your desired location and arrive somewhere else altogether. Otherwise, you and your allies arrive at the desired location at the start of your next turn.
+
+Any effects of spells or items cast before teleporting are dispelled and no longer function on arrival.
+
+#### Epic Feat
+
+Your allies don’t need to be next to you before you cast the spell, just nearby. Alternately, if they are all next to you when you cast the spell, you can teleport to a location known to one of your allies.


### PR DESCRIPTION
Included are the following class files:
- Chaos Mage
- Cleric
- Commander
- Druid
- Fighter
- Monk
- Necromancer
- Occultist
- Paladin
- Ranger
- Rogue
- Sorcerer
- Wizard

With Barbarian and Bard already included in the original repo.

Bard had missing headers, so I included `__` bolding.

I ran a simple lint on the newly created files through obsidian.