### PR TITLE
Add statblocks for the Purple Dragon

### DIFF
--- a/Monsters-Reference/Dragon/The Purple Dragon/Purple Dragon Common Abilities.md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/Purple Dragon Common Abilities.md
@@ -1,0 +1,36 @@
+---
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+# The Purple Dragon, Abilities common to each form and tier  
+
+## Standard Abilities
+
+Rather than repeat these for each entry the following abilities are standard for the Purple Dragon.
+
+_Escalator:_ The Purple Dragon adds the escalation die to their attacks.
+
+_Shape-shifter supreme:_ The Purple Dragon can choose to be in its human form or its dragon form. Switching forms is a move action. Though their dragon form is huge, their human form is regular size, and other forms are whatever size is appropriate to that form. By epic tier the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+
+_[Adventurer and champion tier non-ally only] Cunning escapes:_ When the Purple Dragon drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The Purple Dragon cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+
+_[Once per battle, in human form only] “No, they’re the real Purple Dragon, shoot them!”:_ As a quick action at the end of one of their turns, the Purple Dragon uses their powers of illusion and mind-control to make one of their attackers (usually the closest one to them) look and sound like them; the next attack against the Purple Dragon has a 50% chance of being targeted against the wrong target. Once the next attack is made, the illusion vanishes.
+
+_Flight:_ In their dragon form the Purple Dragon can fly. The Purple Dragon can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+
+_Illusionary soiree:_ Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+
+**1: Sparkling lights**—Ranged attacks against the Purple Dragon or their allies have a -2 penalty.
+
+**2-3: Kaleidoscopic kinescope**—Any attacks against the Purple Dragon this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+
+**4+: Illusionary terrain**—Any of the Purple Dragon’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+
+Nastier Specials
+
+“_You’ve got the wrong person”:_ The Purple Dragon’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape).
+
+_[Epic tier only] Not dead yet:_ The Purple Dragon gets one last _cunning escape_ at epic tier, and though their plans are ruined by their defeat they’ll return one last time to exact their vengeance upon the party.

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Dragon form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Dragon form).md
@@ -45,6 +45,8 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _dragon form_ to their _[[The Purple Dragon (Adventurer, Human Form)|human form]]_.
 traits:
     - name: Escalator
       desc: The __Purple Dragon__ adds the escalation die to their attacks.

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Dragon form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Dragon form).md
@@ -1,0 +1,76 @@
+---
+level: 4
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Adventurer, Dragon form)"
+size: "huge"
+level: "4"
+levelOrdinal: "4th"
+role: "caster"
+type: "dragon"
+initiative: "12"
+actions:
+    - name: "Painted claws +9 vs. AC"
+      desc: "40 damage"
+      traits:
+          - name: "Miss"
+            desc: "14 damage."
+    - name: "C: Psychoactive breath +9 vs. MD (1d4 nearby enemies, or 1d3 faraway enemies in a group)"
+      desc: "25 psychic damage"
+      traits:
+          - name: "Natural even hit"
+            desc: "The target is also dazed (save ends)."
+          - name: "Intermittent breath"
+            desc: "The Purple Dragon can use their _psychoactive breath_ 2d4 times each combat but never two turns in a row. They can choose to make their targets confused (save ends) on a hit or miss with their _psychoactive breath_, but that uses up their breath for the rest of the battle."
+    - name: "Bladed fan +9 vs. AC"
+      desc: "25 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the __Purple Dragon__."
+          - name: "Natural odd miss"
+            desc: "The __Purple Dragon__ pops free and moves away from the target (blown by the wind of the fan)."
+          - name: "Wing buffet"
+            desc: "That _bladed fan_ attack? Yeah, that was the __Purple Dragon__’s wings hidden by an illusion. The __Purple Dragon__ can use the _bladed fan_ attack in this form, but now it is clear that they are using their wings so it is only +9 to attack."
+    - name: "Cloak of illusion"
+      desc: "As a quick action the Purple Dragon fills the battlefield with illusions that give enemies attacking them a -2 penalty to their attacks. This lasts until they next attack."
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The __Purple Dragon__ adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The __Purple Dragon__ can choose to be in its _[[The Purple Dragon (Adventurer, Human form)|human form]]_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form.
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. The __Purple Dragon__ can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the __Purple Dragon__ or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+ac: "20"
+pd: "18"
+md: "20"
+hp: "170"
+```

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Human form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Human form).md
@@ -10,7 +10,7 @@ aliases: ["Purple Dragon", "The Purple Dragon"]
 layout: Basic 13th Age Monster Layout
 columns: 1
 name: "The Purple Dragon (Adventurer, Human form)"
-size: "huge"
+size: "normal"
 level: "4"
 levelOrdinal: "4th"
 role: "caster"
@@ -38,6 +38,8 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _human form_ to their _[[The Purple Dragon (Adventurer, Dragon Form)|dragon form]]_.
 traits:
     - name: Escalator
       desc: The __Purple Dragon__ adds the escalation die to their attacks.

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Human form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Adventurer, Human form).md
@@ -1,0 +1,69 @@
+---
+level: 4
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Adventurer, Human form)"
+size: "huge"
+level: "4"
+levelOrdinal: "4th"
+role: "caster"
+type: "dragon"
+initiative: "12"
+actions:
+    - name: "Bladed fan +10 vs. AC"
+      desc: "25 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the __Purple Dragon__."
+          - name: "Natural odd miss"
+            desc: "The __Purple Dragon__ pops free and moves away from the target (blown by the wind of the fan)."
+    - name: "R: Bedazzling deceptions +9 vs. MD (1d3 nearby enemies)"
+      desc: "10 psychic damage and 10 ongoing psychic damage"
+      traits:
+          - name: "Crit against a target already taking ongoing psychic damage"
+            desc: "The target must start making last gasp saves, if they fail they believe that they are the Purple Dragon. Removing this delusion from the target’s mind is as difficult as turning a petrified character back from stone (hard, but not impossible)."
+          - name: "Miss"
+            desc: "7 psychic damage."
+    - name: "“No, they’re the real Purple Dragon, shoot them!”"
+      desc: As a quick action at the end of one of their turns, the __Purple Dragon__ uses their powers of illusion and mind-control to make one of their attackers (usually the closest one to them) look and sound like them; the next attack against the __Purple Dragon__ has a 50% chance of being targeted against the wrong target. Once the next attack is made, the illusion vanishes.
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The __Purple Dragon__ adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The __Purple Dragon__ can choose to be in its _human form_ or its _[[The Purple Dragon (Adventurer, Dragon form)|dragon form]]_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form.
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic in their _human form_, but prefers to not do so unless they need to fight a flying enemy.
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the __Purple Dragon__ or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because, when they skip town, the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+ac: "20"
+pd: "18"
+md: "20"
+hp: "170"
+```

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Dragon Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Dragon Form).md
@@ -1,0 +1,81 @@
+---
+level: 8
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Champion, Dragon Form)"
+size: "huge"
+level: "8"
+levelOrdinal: "8th"
+role: "caster"
+type: "dragon"
+initiative: "16"
+actions:
+    - name: "Gilded claws +13 vs. AC (2 attacks)"
+      desc: "50 damage"
+      traits:
+          - name: "Miss"
+            desc: "28 damage."
+    - name: "C: Psychoactive breath +13 vs. MD (1d4 nearby enemies, or 1d3 faraway enemies in a group)"
+      desc: "40 psychic damage and 10 ongoing psychic damage"
+      traits:
+          - name: "Natural even hit, once per target per battle"
+            desc: "The target is also dazed and stuck (save once for both effects and the ongoing damage)."
+          - name: "Aftereffect"
+            desc: "Once the target saves against the ongoing damage if the save was a natural odd roll the target is dazed (save ends)."
+          - name: "Intermittent breath"
+            desc: "The Purple Dragon can use their _psychoactive breath_ 2d4 times each combat but never two turns in a row. They can choose to make their targets confused (save ends) on a hit or miss with their _psychoactive breath_, but that uses up their breath for the rest of the battle."
+    - name: "Bladed fan +13 vs. AC"
+      desc: "68 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the Purple Dragon."
+          - name: "Natural odd miss"
+            desc: "The Purple Dragon pops free and moves away from the target (blown by the wind of the fan)."
+          - name: "Wing buffet"
+            desc: "Just like adventurer tier, the _bladed fan_ attack translates in dragon form to wing buffet but with only +13 to attack."
+    - name: "Cloak of illusion"
+      desc: "As a quick action the Purple Dragon fills the battlefield with illusions that give enemies attacking them a -2 penalty to their attacks. This lasts until they next attack."
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The Purple Dragon adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+    - name: "Intermittent breath"
+      desc: "The Purple Dragon can use their _psychoactive breath_ 2d4 times each combat but never two turns in a row. They can choose to make their targets confused (save ends) on a hit or miss with their _psychoactive breath_, but that uses up their breath for the rest of the battle."
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the Purple Dragon or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+ac: "24"
+pd: "22"
+md: "24"
+hp: "450"
+```
+

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Dragon Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Dragon Form).md
@@ -47,11 +47,13 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _dragon form_ to their _[[The Purple Dragon (Champion, Human Form)|human form]]_.
 traits:
     - name: Escalator
       desc: The Purple Dragon adds the escalation die to their attacks.
     - name: Shape-shifter supreme
-      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+      desc: The Purple Dragon can choose to be in its _[[The Purple Dragon (Champion, Human Form)|human form]]_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
     - name: Flight
       desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
     - name: "Intermittent breath"

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Human Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Human Form).md
@@ -1,0 +1,68 @@
+---
+level: 8
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Champion, Human Form)"
+size: "huge"
+level: "8"
+levelOrdinal: "8th"
+role: "caster"
+type: "dragon"
+initiative: "16"
+actions:
+    - name: "Bladed fan +14 vs. AC"
+      desc: "68 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the Purple Dragon."
+          - name: "Natural odd miss"
+            desc: "The Purple Dragon pops free and moves away from the target (blown by the wind of the fan)."
+    - name: "C: Mirrorball burst +13 vs. MD (1d4 nearby or faraway enemies)"
+      desc: "35 damage and 30 ongoing psychic damage"
+      traits:
+          - name: "Target fails a save against the ongoing damage"
+            desc: "The target is dazzled by light and takes a cumulative -1 penalty to attacks (up to a maximum of -4) until the end of the battle."
+    - name: "“No, they’re the real Purple Dragon, shoot them!”"
+      desc: As a quick action at the end of one of their turns, the __Purple Dragon__ uses their powers of illusion and mind-control to make one of their attackers (usually the closest one to them) look and sound like them; the next attack against the __Purple Dragon__ has a 50% chance of being targeted against the wrong target. Once the next attack is made, the illusion vanishes.
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The Purple Dragon adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the Purple Dragon or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+ac: "24"
+pd: "22"
+md: "24"
+hp: "450"
+```
+

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Human Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Champion, Human Form).md
@@ -10,7 +10,7 @@ aliases: ["Purple Dragon", "The Purple Dragon"]
 layout: Basic 13th Age Monster Layout
 columns: 1
 name: "The Purple Dragon (Champion, Human Form)"
-size: "huge"
+size: "normal"
 level: "8"
 levelOrdinal: "8th"
 role: "caster"
@@ -36,11 +36,13 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _humand form_ to their _[[The Purple Dragon (Champion, Dragon Form)|dragon form]]_.
 traits:
     - name: Escalator
       desc: The Purple Dragon adds the escalation die to their attacks.
     - name: Shape-shifter supreme
-      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+      desc: The Purple Dragon can choose to be in its _human form_ or its _[[The Purple Dragon (Champion, Dragon Form)|dragon form]]_. Switching forms is a _move action_. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
     - name: Flight
       desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
     - name: Illusionary soirée

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Dragon Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Dragon Form).md
@@ -47,6 +47,8 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _dragon form_ to their _[[The Purple Dragon (Epic, Human Form)|human form]]_.
 traits:
     - name: Escalator
       desc: The Purple Dragon adds the escalation die to their attacks.

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Dragon Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Dragon Form).md
@@ -1,0 +1,81 @@
+---
+level: 12
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Epic, Dragon Form)"
+size: "huge"
+level: "12"
+levelOrdinal: "12th"
+role: "caster"
+type: "dragon"
+initiative: "20"
+actions:
+    - name: "Filigree-gilded claws +17 vs. AC (4 attacks)"
+      desc: "55 damage"
+      traits:
+          - name: "Miss"
+            desc: "30 damage."
+    - name: "C: Psychoactive breath +17 vs. MD (1d4 nearby enemies, or 1d3 faraway enemies in a group)"
+      desc: "60 psychic damage and 50 ongoing psychic damage"
+      traits:
+          - name: "Natural even hit, once per target per battle"
+            desc: "The target is also weakened and stuck (save once for both effects and the ongoing damage)."
+          - name: "Aftereffect"
+            desc: "Once the target saves against the ongoing damage if the save was a natural odd roll the target is weakened (save ends)."
+          - name: "Intermittent breath"
+            desc: "The Purple Dragon can use their _psychoactive breath_ 2d4 times each combat but never two turns in a row. They can choose to make their targets confused (save ends) on a hit or miss with their _psychoactive breath_, but that uses up their breath for the rest of the battle."
+    - name: "Bladed fan +17 vs. AC"
+      desc: "160 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the Purple Dragon."
+          - name: "Natural odd miss"
+            desc: "The Purple Dragon pops free and moves away from the target (blown by the wind of the fan)."
+          - name: "Wing buffet"
+            desc: "Just like the previous tiers, the _bladed fan_ attack translates in dragon form to wing buffet but with only +17 to attack."
+    - name: "Cloak of illusion"
+      desc: "As a quick action the Purple Dragon fills the battlefield with illusions that give enemies attacking them a -2 penalty to their attacks. This lasts until they next attack."
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The Purple Dragon adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the Purple Dragon or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+    - name: Not dead yet
+      desc: The Purple Dragon gets one last _cunning escape_ at epic tier, and though their plans are ruined by their defeat they’ll return one last time to exact their vengeance upon the party.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+ac: "28"
+pd: "26"
+md: "28"
+hp: "1100"
+```
+

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Human Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Human Form).md
@@ -10,7 +10,7 @@ aliases: ["Purple Dragon", "The Purple Dragon"]
 layout: Basic 13th Age Monster Layout
 columns: 1
 name: "The Purple Dragon (Epic, Human Form)"
-size: "huge"
+size: "normal"
 level: "12"
 levelOrdinal: "12th"
 role: "caster"
@@ -40,6 +40,8 @@ actions:
       traits:
           - name: Limited Use
             desc: 1/battle
+    - name: Shape-shifter supreme
+      desc: As a move action, the Purple Dragon can change from their _human form_ to their _[[The Purple Dragon (Epic, Dragon Form)|dragon form]]_.
 traits:
     - name: Escalator
       desc: The Purple Dragon adds the escalation die to their attacks.

--- a/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Human Form).md
+++ b/Monsters-Reference/Dragon/The Purple Dragon/The Purple Dragon (Epic, Human Form).md
@@ -1,0 +1,74 @@
+---
+level: 12
+role: caster
+type: dragon
+strength: huge
+tags: ["13A/Bestiary/Dragon", "13A/Monsters/Type/caster", "13A/Monsters/Strength/triple"]
+aliases: ["Purple Dragon", "The Purple Dragon"]
+---
+```statblock
+layout: Basic 13th Age Monster Layout
+columns: 1
+name: "The Purple Dragon (Epic, Human Form)"
+size: "huge"
+level: "12"
+levelOrdinal: "12th"
+role: "caster"
+type: "dragon"
+initiative: "20"
+actions:
+    - name: "Bladed fan +18 vs. AC"
+      desc: "160 damage"
+      traits:
+          - name: "Natural even hit or miss"
+            desc: "Make a second _bladed fan_ attack, and if that is a natural even roll make a third _bladed fan_ attack."
+          - name: "Natural odd hit"
+            desc: "The target is blown back from the Purple Dragon."
+          - name: "Natural odd miss"
+            desc: "The Purple Dragon pops free and moves away from the target (blown by the wind of the fan)."
+    - name: "C: One thousand delights +17 vs. MD (1d4 nearby or faraway enemies)"
+      desc: "Target is stuck until the start of their next turn as their mind is assailed by pleasant images pulled from their own inner fantasies"
+      traits:
+          - name: "Natural even hit"
+            desc: "Target is confused (save ends)."
+          - name: "Natural odd hit"
+            desc: "Target is weakened (save ends)."
+          - name: "Aftereffect"
+            desc: "Once the target saves against weakened or confused they take 100 psychic damage for each failed save against the effect before they successfully passed the save."
+    - name: "“No, they’re the real Purple Dragon, shoot them!”"
+      desc: As a quick action at the end of one of their turns, the __Purple Dragon__ uses their powers of illusion and mind-control to make one of their attackers (usually the closest one to them) look and sound like them; the next attack against the __Purple Dragon__ has a 50% chance of being targeted against the wrong target. Once the next attack is made, the illusion vanishes.
+      traits:
+          - name: Limited Use
+            desc: 1/battle
+traits:
+    - name: Escalator
+      desc: The Purple Dragon adds the escalation die to their attacks.
+    - name: Shape-shifter supreme
+      desc: The Purple Dragon can choose to be in its _human form_ or its _dragon form_. Switching forms is a move action. Though their _dragon form_ is huge, their _human form_ is regular size, and other forms are whatever size is appropriate to that form. By epic tier, the Purple Dragon can conceivably take any form, but regardless of tier their vanity limits her to forms that feature purple and magenta (purple clothes and magenta hair, purple scales and magenta wing membranes, etc.).
+    - name: Flight
+      desc: In their _dragon form_ the __Purple Dragon__ can fly. They can also fly using magic, but prefers to not do so unless they need to fight a flying enemy.
+    - name: Illusionary soirée
+      desc: Each round roll a d6 (or a d4 if the fight is at a party or a luxurious lair), if it is equal to or less than the escalation die it has the following effect.
+      traits:
+          - name: "1: Sparkling lights"
+            desc: Ranged attacks against the Purple Dragon or their allies have a -2 penalty.
+          - name: "2-3: Kaleidoscopic kinescope"
+            desc: Any attacks against the __Purple Dragon__ this round that are natural 1s are rerolled against the nearest ally of the attacker (or against the attacker themselves if there is no other possible target).
+          - name: "4+: Illusionary terrain"
+            desc: Any of the __Purple Dragon__’s enemies that move this round must roll a save, on a failure they end up in a place they did not intend.
+nastier_traits:
+    - name: "“You’ve got the wrong person”"
+      desc: "The __Purple Dragon__’s _“No, they’re the real Purple Dragon, shoot them!”_ ability lingers long after the battle, maybe for days. This is probably deliberate magic on their part, because when they skip town the party member that looks and sounds like them will take the fall (or at least create enough confusion for them to make good their escape)."
+    - name: Not dead yet
+      desc: The Purple Dragon gets one last _cunning escape_ at epic tier, and though their plans are ruined by their defeat they’ll return one last time to exact their vengeance upon the party.
+    - name: Cunning escape
+      desc: When the __Purple Dragon__ drops to 0 hp or fewer (or would otherwise die) they are not slain, but instead escapes leaving an illusion in their place. When they escape it is a campaign win for the party, as though they had been killed, and their plans crumble. The __Purple Dragon__ cannot return until the next tier (if defeated at adventurer tier they cannot return until champion tier, if defeated at champion tier they return at epic tier).
+      traits:
+          - name: Limited Use
+            desc: Only if the __Purple Dragon__ is engaged in the battle as an antagonist
+ac: "28"
+pd: "26"
+md: "28"
+hp: "1100"
+```
+


### PR DESCRIPTION
I organized the Actions and Traits for each Purple Dragon variant from the SRD. I made a statblock for each combination of human/dragon form and tiers of play, which each statblock having access to the traits and attacks relevant for it. I have put links from each form to the corresponding other based on the tiers as well to ease switching between the two during combat.

Also, personal choice, I reorganized some traits as actions/attacks in the displayed statblock, because they were essentially actions without an attack roll, and so categorized as traits; I think however that the statblocks would be more usable if displayed as actions (like their shape-shifting ability, or their various illusions).